### PR TITLE
Fix MoreView cooldown timer actor isolation

### DIFF
--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -224,7 +224,7 @@ struct MoreView: View {
     
     private func startCooldownTimer() {
         cooldownTimer?.invalidate()
-        cooldownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
+        cooldownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
             DispatchQueue.main.async {
                 if self.remainingCooldownTime > 0 {
                     self.remainingCooldownTime -= 1
@@ -232,7 +232,7 @@ struct MoreView: View {
                 } else {
                     self.cooldownMessage = nil
                     self.remainingCooldownTime = 0
-                    timer.invalidate()
+                    self.cooldownTimer?.invalidate()
                     self.cooldownTimer = nil
                 }
             }


### PR DESCRIPTION
### Motivation
- Resolve a Swift 6 actor-isolation warning where sending the `timer` callback parameter into a main-actor closure could cause a data race by keeping a non-`Sendable` `Timer` value alive across actor boundaries.

### Description
- Replace the closure parameter for `Timer.scheduledTimer` with `_` to avoid capturing `timer` and invalidate the main-actor-owned `cooldownTimer` via `self.cooldownTimer?.invalidate()` before clearing it in `MoreView.swift`.

### Testing
- Ran `git diff --check` which passed, and `xcodebuild` was not run because Xcode is unavailable in the current (Linux) environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a652d1128a08320b9ee69632ba396f9)