### PR TITLE
Fix Swift 6 cooldown concurrency and bulk report deletion

### DIFF
--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -438,7 +438,12 @@ final class DataManager: ObservableObject {
         Task {
             do {
                 let database = CKContainer(identifier: "iCloud.craftifydb").publicCloudDatabase
-                _ = try await database.modifyRecords(saving: [], deleting: recordIDs)
+                let (_, deleteResults) = try await database.modifyRecords(saving: [], deleting: recordIDs)
+                for result in deleteResults.values {
+                    if case .failure(let error) = result {
+                        throw error
+                    }
+                }
                 accessibilityAnnouncement = "All reports deleted successfully"
                 completion(true)
             } catch {

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -15,7 +15,7 @@ struct MoreView: View {
     @AppStorage("accentColorPreference") private var accentColorPreference: String = "default"
     @State private var cooldownMessage: String? = nil
     @State private var remainingCooldownTime: Int = 0
-    @State private var cooldownTimer: Timer? = nil
+    @State private var cooldownTask: Task<Void, Never>? = nil
     @State private var attemptedSyncWhileOffline: Bool = false
     
     private func formatSyncDate(_ date: Date?) -> String {
@@ -193,8 +193,8 @@ struct MoreView: View {
                 }
             }
             .onDisappear {
-                cooldownTimer?.invalidate()
-                cooldownTimer = nil
+                cooldownTask?.cancel()
+                cooldownTask = nil
                 cooldownMessage = nil
                 remainingCooldownTime = 0
             }
@@ -215,27 +215,32 @@ struct MoreView: View {
                     
                     if self.remainingCooldownTime > 0 {
                         self.cooldownMessage = "Please wait \(self.remainingCooldownTime) second\(self.remainingCooldownTime == 1 ? "" : "s") before syncing again."
-                        self.startCooldownTimer()
+                        self.startCooldownTask()
                     }
                 }
             }
         }
     }
     
-    private func startCooldownTimer() {
-        cooldownTimer?.invalidate()
-        cooldownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            DispatchQueue.main.async {
-                if self.remainingCooldownTime > 0 {
-                    self.remainingCooldownTime -= 1
-                    self.cooldownMessage = "Please wait \(self.remainingCooldownTime) second\(self.remainingCooldownTime == 1 ? "" : "s") before syncing again."
-                } else {
-                    self.cooldownMessage = nil
-                    self.remainingCooldownTime = 0
-                    self.cooldownTimer?.invalidate()
-                    self.cooldownTimer = nil
+    private func startCooldownTask() {
+        cooldownTask?.cancel()
+        cooldownTask = Task { @MainActor in
+            while !Task.isCancelled && remainingCooldownTime > 0 {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+
+                remainingCooldownTime = max(0, remainingCooldownTime - 1)
+                if remainingCooldownTime > 0 {
+                    cooldownMessage = "Please wait \(remainingCooldownTime) second\(remainingCooldownTime == 1 ? "" : "s") before syncing again."
                 }
             }
+
+            guard !Task.isCancelled else { return }
+            cooldownMessage = nil
+            cooldownTask = nil
         }
     }
     

--- a/Craftify/ReportRecipeView.swift
+++ b/Craftify/ReportRecipeView.swift
@@ -27,7 +27,7 @@ struct ReportRecipeView: View {
     @State private var showSubmissionPopup: Bool = false
     @State private var lastSubmissionTime: Date?
     @State private var submissionCooldownMessage: String?
-    @State private var submissionCooldownTimer: Timer?
+    @State private var submissionCooldownTask: Task<Void, Never>?
     @State private var showDeleteConfirmationPopup: Bool = false
     @State private var deleteConfirmationMessage: String?
     @State private var cachedSortedReports: [RecipeReport] = []
@@ -190,6 +190,12 @@ struct ReportRecipeView: View {
                     if viewMode == .myReports {
                         fetchReportStatuses()
                     }
+                    if isSubmissionOnCooldown {
+                        updateSubmissionCooldownMessage()
+                        startSubmissionCooldownTask()
+                    } else {
+                        submissionCooldownMessage = nil
+                    }
                 }
                 .onChange(of: viewMode) { _, newValue in
                     if newValue == .myReports {
@@ -199,6 +205,10 @@ struct ReportRecipeView: View {
                 }
                 .onChange(of: reportType) { _, _ in
                     resetForm()
+                }
+                .onDisappear {
+                    submissionCooldownTask?.cancel()
+                    submissionCooldownTask = nil
                 }
             }
         }
@@ -216,17 +226,23 @@ struct ReportRecipeView: View {
         submissionCooldownMessage = "Please wait \(remaining) second\(remaining == 1 ? "" : "s") before submitting again."
     }
 
-    private func startSubmissionCooldownTimer() {
-        submissionCooldownTimer?.invalidate()
-        submissionCooldownTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
-            DispatchQueue.main.async {
+    private func startSubmissionCooldownTask() {
+        submissionCooldownTask?.cancel()
+        submissionCooldownTask = Task { @MainActor in
+            while !Task.isCancelled {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return
+                }
+
                 let remaining = self.remainingSubmissionCooldown
                 if remaining > 0 {
                     self.updateSubmissionCooldownMessage()
                 } else {
                     self.submissionCooldownMessage = nil
-                    timer.invalidate()
-                    self.submissionCooldownTimer = nil
+                    self.submissionCooldownTask = nil
+                    return
                 }
             }
         }
@@ -261,7 +277,7 @@ struct ReportRecipeView: View {
                     )
                     self.lastSubmissionTime = Date()
                     self.updateSubmissionCooldownMessage()
-                    self.startSubmissionCooldownTimer()
+                    self.startSubmissionCooldownTask()
                 case .failure(let error):
                     self.submissionState = .failure("Failed to submit report: \(error.localizedDescription)")
                 }


### PR DESCRIPTION
### Motivation

- Eliminate Swift 6 data-race warnings caused by crossing a non-Sendable `Timer` between actor contexts by replacing `Timer` usage with structured concurrency tasks. 
- Make bulk CloudKit deletions robust by examining per-record deletion results so the app does not incorrectly announce success when individual deletes fail. 
- Ensure the cooldown behavior resumes correctly when views reappear and cancel background work when views disappear. 
- Confirm the Xcode 26.3 project-format update does not require source code changes.

### Description

- Replaced `Timer`-based cooldown in `MoreView.swift` with a cancellable `Task<Void, Never>` stored as `@State private var cooldownTask`, introduced `startCooldownTask()` and cancel the task on view disappearance. 
- Replaced submission cooldown in `ReportRecipeView.swift` with a cancellable `Task<Void, Never>` stored as `@State private var submissionCooldownTask`, introduced `startSubmissionCooldownTask()`, resume the cooldown when the view appears, and cancel on disappearance. 
- Updated `DataManager.deleteAllRecipeReports(...)` to capture `(_, deleteResults) = try await database.modifyRecords(...)` and iterate `deleteResults.values` to throw on any `.failure(...)` so partial failures are reported via the existing error path. 
- Audited Swift sources to remove remaining `Timer`, `Timer.scheduledTimer`, and `invalidate()` usages and renamed usages to task-based helpers (`startCooldownTask` / `startSubmissionCooldownTask`) so concurrency isolation warnings are resolved.

### Testing

- Parsed all Swift sources with `swiftc -frontend -parse` which completed successfully. 
- Audited sources with a regex search for `Timer`, `Timer.scheduledTimer`, and `invalidate()` and confirmed no Foundation `Timer` APIs remain in Swift sources. 
- Verified the bulk-delete change by ensuring the code inspects `deleteResults` from `modifyRecords` and routes failures to the error path. 
- Noted that `xcodebuild` / a full Xcode macOS build was not available in the Linux environment, so a full iOS build could not be executed in this CI environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a652edc72d48320b3cecf29b70f8d06)