### PR TITLE
Refine onboarding, haptics, and About navigation

### DIFF
--- a/Craftify/AppAppearanceView.swift
+++ b/Craftify/AppAppearanceView.swift
@@ -14,7 +14,7 @@ private struct AppIcon: Identifiable {
     let previewName: String
 }
 
-private struct AccentColorOption: Identifiable {
+struct AccentColorOption: Identifiable {
     let id: String
     let name: String
     let color: Color
@@ -40,7 +40,7 @@ struct AppAppearanceView: View {
         .init(id: "AlternateIcon2", name: "Craftify Grid", previewName: "AlternateIcon2Preview")
     ]
 
-    private let accentColors: [AccentColorOption] = [
+    static let accentColors: [AccentColorOption] = [
         .init(id: "default", name: "Default", color: Color(hex: "00AA00")),
         .init(id: "blue", name: "Blue", color: .blue),
         .init(id: "orange", name: "Orange", color: .orange),
@@ -66,7 +66,7 @@ struct AppAppearanceView: View {
             
             Section(header: Text("Accent Color")) {
                 Picker("Accent Color", selection: $accentColorPreference) {
-                    ForEach(accentColors) { option in
+                    ForEach(Self.accentColors) { option in
                         HStack {
                             Circle()
                                 .fill(option.color)
@@ -159,7 +159,7 @@ struct AppAppearanceView: View {
     }
 
     private func changeIcon(to: String?) {
-        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        Haptics.impact(.medium)
         UIApplication.shared.setAlternateIconName(to) { error in
             DispatchQueue.main.async {
                 if let err = error {

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -10,17 +10,6 @@ import Combine
 import CloudKit
 import UIKit
 
-// Applies the frosted-glass only on iOS 17 for the tab bar
-private struct iOS17TabBarBackground: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(iOS 18.0, *) {
-            return content
-        } else {
-            return content.toolbarBackground(.ultraThinMaterial, for: .tabBar)
-        }
-    }
-}
-
 struct ContentView: View {
     @EnvironmentObject private var dataManager: DataManager
     @AppStorage("colorSchemePreference") private var colorSchemePreference: String = "system"
@@ -69,8 +58,7 @@ struct ContentView: View {
                 RecipeSearchView()
                     .tabItem {
                         // on iPadOS 18+, show icon-only
-                        if UIDevice.current.userInterfaceIdiom == .pad,
-                           #available(iOS 18.0, *) {
+                        if UIDevice.current.userInterfaceIdiom == .pad {
                             Image(systemName: "magnifyingglass")
                         } else {
                             Label("Search", systemImage: "magnifyingglass")
@@ -115,9 +103,8 @@ struct ContentView: View {
                     .ignoresSafeArea()
             }
         }
-        .modifier(iOS17TabBarBackground())
         .onChange(of: selectedTab) { _, newValue in
-            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            Haptics.selection()
             UIAccessibility.post(
                 notification: .announcement,
                 argument: "Selected tab: \(tabName(for: newValue))"
@@ -258,7 +245,7 @@ struct CategoryFilterBar: View {
             HStack(spacing: 8) {
                 Button {
                     selectedCategory = nil
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    Haptics.selection()
                 } label: {
                     Text("All")
                         .font(.body)
@@ -285,7 +272,7 @@ struct CategoryFilterBar: View {
                 ForEach(categories, id: \.self) { category in
                     Button {
                         selectedCategory = category
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        Haptics.selection()
                     } label: {
                         Text(category)
                             .font(.body)

--- a/Craftify/CraftifyApp.swift
+++ b/Craftify/CraftifyApp.swift
@@ -11,21 +11,18 @@ import UIKit
 @main
 struct CraftifyApp: App {
     init() {
-        if #available(iOS 17.0, *) {
-            let tabBarAppearance = UITabBarAppearance()
-            if #available(iOS 26.0, *) {
+        let tabBarAppearance = UITabBarAppearance()
+        if #available(iOS 26.0, *) {
                 // Liquid Glass: Use transparent background with vibrancy
                 tabBarAppearance.configureWithTransparentBackground()
                 let blurEffect = UIBlurEffect(style: .systemUltraThinMaterial)
                 tabBarAppearance.backgroundEffect = blurEffect
                 tabBarAppearance.backgroundColor = UIColor.systemBackground.withAlphaComponent(0.1)
-            } else {
-                // iOS 17–25: Default background for bug fixes
-                tabBarAppearance.configureWithDefaultBackground()
-            }
-            UITabBar.appearance().standardAppearance = tabBarAppearance
-            UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+        } else {
+            tabBarAppearance.configureWithDefaultBackground()
         }
+        UITabBar.appearance().standardAppearance = tabBarAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
     }
 
     @StateObject private var dataManager = DataManager()
@@ -39,8 +36,6 @@ struct CraftifyApp: App {
             ZStack {
                 ContentView()
                     .environmentObject(dataManager)
-                    .opacity(showOnboarding ? 0.0 : 1.0)
-                    .animation(.easeInOut(duration: 0.3), value: showOnboarding)
 
                 if showOnboarding {
                     OnboardingView(
@@ -67,7 +62,6 @@ struct CraftifyApp: App {
                         horizontalSizeClass: UIDevice.current.userInterfaceIdiom == .pad ? .regular : .compact
                     )
                     .environmentObject(dataManager)
-                    .ignoresSafeArea(.container, edges: .top)
                     .background {
                         if #available(iOS 26.0, *) {
                             // Liquid Glass: Vibrant, translucent background

--- a/Craftify/FavoritesView.swift
+++ b/Craftify/FavoritesView.swift
@@ -131,7 +131,7 @@ struct FavoritesView: View {
                         HStack(spacing: hStackSpacing) {
                             Button {
                                 selectedCategory = nil
-                                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                Haptics.impact()
                             } label: {
                                 Text("All")
                                     .font(.body)
@@ -148,7 +148,7 @@ struct FavoritesView: View {
                             ForEach(favoriteCategories, id: \.self) { category in
                                 Button {
                                     selectedCategory = category
-                                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                    Haptics.impact()
                                 } label: {
                                     Text(category)
                                         .font(.body)

--- a/Craftify/Haptics.swift
+++ b/Craftify/Haptics.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+/// A single, prepared entry point for tactile feedback throughout Craftify.
+@MainActor
+enum Haptics {
+    static func selection() {
+        let generator = UISelectionFeedbackGenerator()
+        generator.prepare()
+        generator.selectionChanged()
+    }
+
+    static func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle = .light) {
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+
+    static func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(type)
+    }
+}

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -34,12 +34,14 @@ struct MoreView: View {
                     NavigationLink(destination: ReportRecipeView()) {
                         buttonStyle(title: "Report Issue", systemImage: "envelope.fill")
                     }
+                    .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
                     .accessibilityLabel("Report Issue")
                     .accessibilityHint("Navigate to report a missing recipe or an error in an existing recipe")
                     
                     NavigationLink(destination: CommandsView()) {
                         buttonStyle(title: "Console Commands", systemImage: "terminal.fill")
                     }
+                    .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
                     .accessibilityLabel("Console Commands")
                     .accessibilityHint("Navigate to view in-game console commands")
                 }
@@ -48,6 +50,7 @@ struct MoreView: View {
                     NavigationLink(destination: AboutView(accentColorPreference: accentColorPreference)) {
                         buttonStyle(title: "About Craftify", systemImage: "info.circle.fill")
                     }
+                    .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
                     .accessibilityLabel("About Craftify")
                     .accessibilityHint("View information about the Craftify app")
                     
@@ -64,6 +67,7 @@ struct MoreView: View {
                         // 1. Sync Recipes Button + Cooldown Message
                         VStack(spacing: 8) {
                             Button(action: {
+                                Haptics.impact(.medium)
                                 fetchRecipes(isUserInitiated: true)
                             }) {
                                 HStack {
@@ -331,13 +335,12 @@ struct AboutView: View {
             .accessibilityLabel("Craftify for Minecraft, \(appVersion). Craftify helps you manage your recipes and favorites.")
             .accessibilityHint("About the Craftify app and its purpose")
             
-            List {
-                Section {
-                    NavigationLink(destination: AppAppearanceView()) {
+            VStack(spacing: 0) {
+                NavigationLink(destination: AppAppearanceView()) {
                         buttonStyle(title: "App Appearance", systemImage: "app.badge.fill")
                     }
                     .simultaneousGesture(TapGesture().onEnded {
-                        // Haptics removed to avoid UIKit dependency
+                        Haptics.selection()
                     })
                     .buttonStyle(.plain)
                     .listRowInsets(EdgeInsets(
@@ -348,12 +351,15 @@ struct AboutView: View {
                     ))
                     .accessibilityLabel("App Appearance")
                     .accessibilityHint("Customize the app's icon and appearance settings")
-                    
-                    NavigationLink(destination: ReleaseNotesView()) {
+
+                Divider()
+                    .padding(.leading, 44)
+
+                NavigationLink(destination: ReleaseNotesView()) {
                         buttonStyle(title: "Release Notes", systemImage: "doc.text.fill")
                     }
                     .simultaneousGesture(TapGesture().onEnded {
-                        // Haptics removed to avoid UIKit dependency
+                        Haptics.selection()
                     })
                     .buttonStyle(.plain)
                     .listRowInsets(EdgeInsets(
@@ -364,9 +370,8 @@ struct AboutView: View {
                     ))
                     .accessibilityLabel("Release Notes")
                     .accessibilityHint("View the release notes for Craftify")
-                }
             }
-            .listStyle(InsetGroupedListStyle())
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
             .padding(.horizontal, horizontalSizeClass == .regular ? 12 : 8)
             
             NavigationLink(destination: SupportView()) {
@@ -386,6 +391,7 @@ struct AboutView: View {
                 .foregroundColor(.white)
                 .clipShape(RoundedRectangle(cornerRadius: 16))
             }
+            .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
             .frame(maxWidth: horizontalSizeClass == .regular ? 600 : 400)
             .padding(.bottom, 8)
             .accessibilityLabel("Support and Privacy")

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -124,17 +124,6 @@ struct OnboardingView: View {
 
     private var onboardingPages: some View {
         VStack(spacing: 0) {
-            HStack {
-                appMark.compact
-                Spacer()
-                Text("\(step + 1) of \(pages.count)")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .contentTransition(.numericText())
-            }
-            .padding(.horizontal, pagePadding)
-            .padding(.top, 12)
-
             TabView(selection: $step) {
                 ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
                     OnboardingPageView(page: page, isCurrent: step == index)
@@ -204,12 +193,8 @@ struct OnboardingView: View {
 
     private func finishOnboarding() {
         guard !isFinishing else { return }
-        withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.3)) {
-            isFinishing = true
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + (reduceMotion ? 0 : 0.3)) {
-            onDismiss()
-        }
+        isFinishing = true
+        onDismiss()
     }
 }
 
@@ -217,6 +202,7 @@ private struct OnboardingPageView: View {
     let page: OnboardingPage
     let isCurrent: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
 
     var body: some View {
         ScrollView {
@@ -272,6 +258,39 @@ private struct OnboardingPageView: View {
                 }
                 .frame(maxWidth: 520)
 
+                if page.title == "Keep favorites close" {
+                    VStack(alignment: .leading, spacing: 12) {
+                        Label("Choose an appearance that feels like yours", systemImage: "paintpalette.fill")
+                            .font(.subheadline.weight(.semibold))
+
+                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 44), spacing: 12)], spacing: 12) {
+                            ForEach(AppAppearanceView.accentColors) { option in
+                                Button {
+                                    accentColorPreference = option.id
+                                    Haptics.selection()
+                                } label: {
+                                    Circle()
+                                        .fill(option.color)
+                                        .frame(width: 34, height: 34)
+                                        .overlay {
+                                            if accentColorPreference == option.id {
+                                                Image(systemName: "checkmark")
+                                                    .font(.caption.bold())
+                                                    .foregroundStyle(.white)
+                                            }
+                                        }
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel(option.name)
+                                .accessibilityValue(accentColorPreference == option.id ? "Selected" : "")
+                            }
+                        }
+                    }
+                    .padding(14)
+                    .frame(maxWidth: 520)
+                    .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                }
+
                 Spacer(minLength: 18)
             }
             .frame(maxWidth: .infinity)
@@ -296,15 +315,6 @@ private struct AppMark: View {
         .accessibilityHidden(true)
     }
 
-    var compact: some View {
-        HStack(spacing: 10) {
-            AppMark(size: 38)
-            Text("Craftify")
-                .font(.headline)
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Craftify")
-    }
 }
 
 private struct CraftifyPrimaryButtonStyle: ButtonStyle {
@@ -362,7 +372,7 @@ private struct OnboardingPage {
             symbol: "heart.fill",
             highlights: [
                 Highlight(symbol: "heart.circle", text: "Build a personal shortlist for every project"),
-                Highlight(symbol: "paintpalette", text: "Choose an appearance that feels like yours")
+                Highlight(symbol: "icloud", text: "Favorites sync across all your devices")
             ]
         )
     ]

--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -69,6 +69,7 @@ struct RecipeDetailView: View {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
                     feedbackGenerator.impactOccurred()
+                    feedbackGenerator.prepare()
                     withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
                         animateHeart = true
                     }
@@ -245,7 +246,7 @@ struct AlternateRecipesSelector: View {
                 HStack(spacing: 8) {
                     ForEach(0..<ingredientSets.count, id: \.self) { index in
                         Button {
-                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            Haptics.impact()
                             withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
                                 selectedCraftingOption = index
                                 selectedDetail = nil
@@ -377,6 +378,7 @@ struct IngredientDetailPopup: View {
 
             Button {
                 feedbackGenerator.impactOccurred()
+                feedbackGenerator.prepare()
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
                     selectedDetail = nil
                     selectedItem = nil
@@ -452,6 +454,7 @@ struct RemarkAndCategoryView: View {
                     .accessibilityHint("Tap to view remarks")
                     .onTapGesture {
                         feedbackGenerator.impactOccurred()
+                        feedbackGenerator.prepare()
                         withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
                             selectedDetail = imageRemark
                             selectedItem = .imageremark
@@ -562,6 +565,7 @@ struct GridView: View {
                     .accessibilityHint("Tap to view details")
                     .onTapGesture {
                         feedbackGenerator.impactOccurred()
+                        feedbackGenerator.prepare()
                         withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
                             selectedDetail = recipe.name
                             selectedItem = .output
@@ -715,6 +719,7 @@ struct GridCell: View {
         .onTapGesture {
             guard !ingredient.isEmpty else { return }
             feedbackGenerator.impactOccurred()
+            feedbackGenerator.prepare()
             withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
                 onTap()
             }

--- a/Craftify/RecipeSearchView.swift
+++ b/Craftify/RecipeSearchView.swift
@@ -122,7 +122,7 @@ struct RecipeSearchView: View {
 
                                     Button(action: {
                                         clearRecentSearches()
-                                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                                        Haptics.impact(.medium)
                                     }) {
                                         Text("Clear All")
                                             .font(.subheadline)
@@ -164,7 +164,7 @@ struct RecipeSearchView: View {
                         .accessibilityHint("Choose to search all recipes or only favorite recipes")
                         .onChange(of: searchFilter) { _, _ in
                             updateFilteredRecipes()
-                            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                            Haptics.impact()
                         }
 
                         if searchText.isEmpty {
@@ -237,7 +237,7 @@ struct RecipeSearchView: View {
                                                 RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
                                                     .onAppear {
                                                         saveRecentSearch(recipe)
-                                                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                                                        Haptics.impact()
                                                     }
                                             } label: {
                                                 RecipeCell(recipe: recipe, isCraftifyPick: false)

--- a/Craftify/ReportRecipeView.swift
+++ b/Craftify/ReportRecipeView.swift
@@ -379,7 +379,7 @@ struct SubmitReportSection: View {
             }
 
             Button(action: {
-                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                Haptics.impact(.medium)
                 if isFormIncomplete {
                     return
                 }

--- a/Craftify/SupportView.swift
+++ b/Craftify/SupportView.swift
@@ -20,7 +20,7 @@ struct SupportView: View {
             List {
                 Section(header: Text("Support").font(.headline).minimumScaleFactor(0.6)) {
                     Button(action: {
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                        Haptics.impact(.medium)
                         let supportEmail = "hello@davevancauwenberghe.be"
                         if let url = URL(string: "mailto:\(supportEmail)") {
                             UIApplication.shared.open(url)
@@ -41,8 +41,8 @@ struct SupportView: View {
 
                 Section(header: Text("Data Management").font(.headline).minimumScaleFactor(0.6)) {
                     Button(action: {
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                        UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                        Haptics.impact(.medium)
+                        Haptics.notification(.warning)
                         showClearDataAlert = true
                     }) {
                         buttonStyle(title: "Clear All Data", systemImage: "trash.fill", foregroundColor: .red)
@@ -68,7 +68,7 @@ struct SupportView: View {
                         .accessibilityHint("This will permanently delete all your favorites, recent searches, recipe reports, and the local recipe cache.")
 
                     Button(action: {
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                        Haptics.impact(.medium)
                         dataManager.clearCache { success in
                             if !success {
                                 errorMessage = dataManager.errorMessage ?? "Failed to clear cache. Please try again."
@@ -101,7 +101,7 @@ struct SupportView: View {
 
                 Section(header: Text("Privacy").font(.headline).minimumScaleFactor(0.6)) {
                     Button(action: {
-                        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                        Haptics.impact(.medium)
                         if let url = URL(string: "https://www.davevancauwenberghe.be/projects/craftify-for-minecraft/privacy-policy/") {
                             UIApplication.shared.open(url)
                         }


### PR DESCRIPTION
### Motivation
- Remove the onboarding header artwork that sits in the unsafe top area because it collides with the status bar and looks wrong. 
- Let users pick their preferred app accent color directly from the onboarding “Keep favorites close” page and explicitly tell them favorites sync across devices. 
- Make the onboarding -> main ContentView transition feel immediate and avoid briefly showing an empty view. 
- Remove leftover iOS 17 compatibility code and centralize haptics so tactile feedback is consistent and reliable across the app, and prevent an About screen scrolling issue that dragged down the large navigation title.

### Description
- Removed the compact onboarding header artwork and the unsafe top visuals from `OnboardingView.swift` and simplified `finishOnboarding()` to dismiss immediately so the underlying `ContentView` is revealed without an intermediate empty screen. 
- Added an inline accent-color chooser to the onboarding page by exposing `AppAppearanceView` accent colors (`AppAppearanceView.accentColors`) and wiring selection to `@AppStorage("accentColorPreference")` so users can pick their app color during onboarding. 
- Updated the onboarding copy/highlight for favorites to state that favorites sync across devices (replaced the paint-palette highlight with an iCloud/favorites sync message). 
- Removed obsolete iOS 17 availability branches and the iOS17-specific tab-bar modifier from `ContentView.swift` and `CraftifyApp.swift` now that deployment target is iOS/iPadOS 18.0, and simplified tab-bar appearance initialization. 
- Introduced `Haptics.swift` (centralized `selection()`, `impact(_:)`, and `notification(_:)`) and replaced ad-hoc `UIImpactFeedbackGenerator`/`UINotificationFeedbackGenerator` usages across multiple views with the new helpers for consistent, prepared haptics. 
- Reworked the About/App Appearance area in `MoreView.swift`/`AboutView` to replace the nested, independently scrolling `List` with a fixed, material-backed `VStack` of navigation buttons so tapping those controls no longer causes the large navigation title to collapse, and added small UI polish (divider, material background) and haptics on navigation links. 
- Small safety/UX changes: added `feedbackGenerator.prepare()` calls where appropriate and tuned a few button gestures to use `Haptics`.

### Testing
- Ran `git diff --check` and addressed issues; the diff check succeeded. 
- Verified no obsolete iOS 17 availability checks remain by searching the Swift sources with `rg`/ripgrep; the search returned no iOS 17 compatibility references. 
- Confirmed repository state with `git status --short` and committed the changes (commit message: "Refine onboarding, haptics, and About navigation"). 
- Attempted an `xcodebuild` invocation to build the app for the simulator, but `xcodebuild` is unavailable in this Linux environment so a local Xcode build and simulator run were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a654c569fc083209e6edb79cb685352)