### PR TITLE
Fix haptic feedback resolution in onboarding

### DIFF
--- a/Craftify/AppAppearanceView.swift
+++ b/Craftify/AppAppearanceView.swift
@@ -159,7 +159,7 @@ struct AppAppearanceView: View {
     }
 
     private func changeIcon(to: String?) {
-        Haptics.impact(.medium)
+        HapticFeedback.impact(.medium)
         UIApplication.shared.setAlternateIconName(to) { error in
             DispatchQueue.main.async {
                 if let err = error {

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -104,7 +104,7 @@ struct ContentView: View {
             }
         }
         .onChange(of: selectedTab) { _, newValue in
-            Haptics.selection()
+            HapticFeedback.selection()
             UIAccessibility.post(
                 notification: .announcement,
                 argument: "Selected tab: \(tabName(for: newValue))"
@@ -245,7 +245,7 @@ struct CategoryFilterBar: View {
             HStack(spacing: 8) {
                 Button {
                     selectedCategory = nil
-                    Haptics.selection()
+                    HapticFeedback.selection()
                 } label: {
                     Text("All")
                         .font(.body)
@@ -272,7 +272,7 @@ struct CategoryFilterBar: View {
                 ForEach(categories, id: \.self) { category in
                     Button {
                         selectedCategory = category
-                        Haptics.selection()
+                        HapticFeedback.selection()
                     } label: {
                         Text(category)
                             .font(.body)

--- a/Craftify/FavoritesView.swift
+++ b/Craftify/FavoritesView.swift
@@ -131,7 +131,7 @@ struct FavoritesView: View {
                         HStack(spacing: hStackSpacing) {
                             Button {
                                 selectedCategory = nil
-                                Haptics.impact()
+                                HapticFeedback.impact()
                             } label: {
                                 Text("All")
                                     .font(.body)
@@ -148,7 +148,7 @@ struct FavoritesView: View {
                             ForEach(favoriteCategories, id: \.self) { category in
                                 Button {
                                     selectedCategory = category
-                                    Haptics.impact()
+                                    HapticFeedback.impact()
                                 } label: {
                                     Text(category)
                                         .font(.body)

--- a/Craftify/HapticFeedback.swift
+++ b/Craftify/HapticFeedback.swift
@@ -1,8 +1,10 @@
 import UIKit
 
 /// A single, prepared entry point for tactile feedback throughout Craftify.
+///
+/// Its app-specific name keeps call sites distinct from system haptics APIs.
 @MainActor
-enum Haptics {
+enum HapticFeedback {
     static func selection() {
         let generator = UISelectionFeedbackGenerator()
         generator.prepare()

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -34,14 +34,14 @@ struct MoreView: View {
                     NavigationLink(destination: ReportRecipeView()) {
                         buttonStyle(title: "Report Issue", systemImage: "envelope.fill")
                     }
-                    .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
+                    .simultaneousGesture(TapGesture().onEnded { HapticFeedback.selection() })
                     .accessibilityLabel("Report Issue")
                     .accessibilityHint("Navigate to report a missing recipe or an error in an existing recipe")
                     
                     NavigationLink(destination: CommandsView()) {
                         buttonStyle(title: "Console Commands", systemImage: "terminal.fill")
                     }
-                    .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
+                    .simultaneousGesture(TapGesture().onEnded { HapticFeedback.selection() })
                     .accessibilityLabel("Console Commands")
                     .accessibilityHint("Navigate to view in-game console commands")
                 }
@@ -50,7 +50,7 @@ struct MoreView: View {
                     NavigationLink(destination: AboutView(accentColorPreference: accentColorPreference)) {
                         buttonStyle(title: "About Craftify", systemImage: "info.circle.fill")
                     }
-                    .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
+                    .simultaneousGesture(TapGesture().onEnded { HapticFeedback.selection() })
                     .accessibilityLabel("About Craftify")
                     .accessibilityHint("View information about the Craftify app")
                     
@@ -67,7 +67,7 @@ struct MoreView: View {
                         // 1. Sync Recipes Button + Cooldown Message
                         VStack(spacing: 8) {
                             Button(action: {
-                                Haptics.impact(.medium)
+                                HapticFeedback.impact(.medium)
                                 fetchRecipes(isUserInitiated: true)
                             }) {
                                 HStack {
@@ -340,7 +340,7 @@ struct AboutView: View {
                         buttonStyle(title: "App Appearance", systemImage: "app.badge.fill")
                     }
                     .simultaneousGesture(TapGesture().onEnded {
-                        Haptics.selection()
+                        HapticFeedback.selection()
                     })
                     .buttonStyle(.plain)
                     .listRowInsets(EdgeInsets(
@@ -359,7 +359,7 @@ struct AboutView: View {
                         buttonStyle(title: "Release Notes", systemImage: "doc.text.fill")
                     }
                     .simultaneousGesture(TapGesture().onEnded {
-                        Haptics.selection()
+                        HapticFeedback.selection()
                     })
                     .buttonStyle(.plain)
                     .listRowInsets(EdgeInsets(
@@ -391,7 +391,7 @@ struct AboutView: View {
                 .foregroundColor(.white)
                 .clipShape(RoundedRectangle(cornerRadius: 16))
             }
-            .simultaneousGesture(TapGesture().onEnded { Haptics.selection() })
+            .simultaneousGesture(TapGesture().onEnded { HapticFeedback.selection() })
             .frame(maxWidth: horizontalSizeClass == .regular ? 600 : 400)
             .padding(.bottom, 8)
             .accessibilityLabel("Support and Privacy")

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -263,28 +263,7 @@ private struct OnboardingPageView: View {
                         Label("Choose an appearance that feels like yours", systemImage: "paintpalette.fill")
                             .font(.subheadline.weight(.semibold))
 
-                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 44), spacing: 12)], spacing: 12) {
-                            ForEach(AppAppearanceView.accentColors) { option in
-                                Button {
-                                    accentColorPreference = option.id
-                                    Haptics.selection()
-                                } label: {
-                                    Circle()
-                                        .fill(option.color)
-                                        .frame(width: 34, height: 34)
-                                        .overlay {
-                                            if accentColorPreference == option.id {
-                                                Image(systemName: "checkmark")
-                                                    .font(.caption.bold())
-                                                    .foregroundStyle(.white)
-                                            }
-                                        }
-                                }
-                                .buttonStyle(.plain)
-                                .accessibilityLabel(option.name)
-                                .accessibilityValue(accentColorPreference == option.id ? "Selected" : "")
-                            }
-                        }
+                        accentColorPicker
                     }
                     .padding(14)
                     .frame(maxWidth: 520)
@@ -296,6 +275,43 @@ private struct OnboardingPageView: View {
             .frame(maxWidth: .infinity)
         }
         .scrollIndicators(.hidden)
+    }
+
+    private var accentColorPicker: some View {
+        let columns = [GridItem(.adaptive(minimum: 44), spacing: 12)]
+
+        return LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(AppAppearanceView.accentColors) { option in
+                accentColorButton(for: option)
+            }
+        }
+    }
+
+    private func accentColorButton(for option: AccentColorOption) -> some View {
+        let isSelected = accentColorPreference == option.id
+
+        return Button {
+            selectAccentColor(option.id)
+        } label: {
+            Circle()
+                .fill(option.color)
+                .frame(width: 34, height: 34)
+                .overlay {
+                    if isSelected {
+                        Image(systemName: "checkmark")
+                            .font(.caption.bold())
+                            .foregroundStyle(.white)
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(option.name)
+        .accessibilityValue(isSelected ? "Selected" : "")
+    }
+
+    private func selectAccentColor(_ id: String) {
+        accentColorPreference = id
+        HapticFeedback.selection()
     }
 }
 

--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -246,7 +246,7 @@ struct AlternateRecipesSelector: View {
                 HStack(spacing: 8) {
                     ForEach(0..<ingredientSets.count, id: \.self) { index in
                         Button {
-                            Haptics.impact()
+                            HapticFeedback.impact()
                             withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
                                 selectedCraftingOption = index
                                 selectedDetail = nil

--- a/Craftify/RecipeSearchView.swift
+++ b/Craftify/RecipeSearchView.swift
@@ -122,7 +122,7 @@ struct RecipeSearchView: View {
 
                                     Button(action: {
                                         clearRecentSearches()
-                                        Haptics.impact(.medium)
+                                        HapticFeedback.impact(.medium)
                                     }) {
                                         Text("Clear All")
                                             .font(.subheadline)
@@ -164,7 +164,7 @@ struct RecipeSearchView: View {
                         .accessibilityHint("Choose to search all recipes or only favorite recipes")
                         .onChange(of: searchFilter) { _, _ in
                             updateFilteredRecipes()
-                            Haptics.impact()
+                            HapticFeedback.impact()
                         }
 
                         if searchText.isEmpty {
@@ -237,7 +237,7 @@ struct RecipeSearchView: View {
                                                 RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
                                                     .onAppear {
                                                         saveRecentSearch(recipe)
-                                                        Haptics.impact()
+                                                        HapticFeedback.impact()
                                                     }
                                             } label: {
                                                 RecipeCell(recipe: recipe, isCraftifyPick: false)

--- a/Craftify/ReportRecipeView.swift
+++ b/Craftify/ReportRecipeView.swift
@@ -379,7 +379,7 @@ struct SubmitReportSection: View {
             }
 
             Button(action: {
-                Haptics.impact(.medium)
+                HapticFeedback.impact(.medium)
                 if isFormIncomplete {
                     return
                 }

--- a/Craftify/SupportView.swift
+++ b/Craftify/SupportView.swift
@@ -20,7 +20,7 @@ struct SupportView: View {
             List {
                 Section(header: Text("Support").font(.headline).minimumScaleFactor(0.6)) {
                     Button(action: {
-                        Haptics.impact(.medium)
+                        HapticFeedback.impact(.medium)
                         let supportEmail = "hello@davevancauwenberghe.be"
                         if let url = URL(string: "mailto:\(supportEmail)") {
                             UIApplication.shared.open(url)
@@ -41,8 +41,8 @@ struct SupportView: View {
 
                 Section(header: Text("Data Management").font(.headline).minimumScaleFactor(0.6)) {
                     Button(action: {
-                        Haptics.impact(.medium)
-                        Haptics.notification(.warning)
+                        HapticFeedback.impact(.medium)
+                        HapticFeedback.notification(.warning)
                         showClearDataAlert = true
                     }) {
                         buttonStyle(title: "Clear All Data", systemImage: "trash.fill", foregroundColor: .red)
@@ -68,7 +68,7 @@ struct SupportView: View {
                         .accessibilityHint("This will permanently delete all your favorites, recent searches, recipe reports, and the local recipe cache.")
 
                     Button(action: {
-                        Haptics.impact(.medium)
+                        HapticFeedback.impact(.medium)
                         dataManager.clearCache { success in
                             if !success {
                                 errorMessage = dataManager.errorMessage ?? "Failed to clear cache. Please try again."
@@ -101,7 +101,7 @@ struct SupportView: View {
 
                 Section(header: Text("Privacy").font(.headline).minimumScaleFactor(0.6)) {
                     Button(action: {
-                        Haptics.impact(.medium)
+                        HapticFeedback.impact(.medium)
                         if let url = URL(string: "https://www.davevancauwenberghe.be/projects/craftify-for-minecraft/privacy-policy/") {
                             UIApplication.shared.open(url)
                         }


### PR DESCRIPTION
### Motivation
- The app-level `Haptics` helper name conflicted with system/framework symbols and caused unresolved symbol errors and slow compiler type-checking in complex SwiftUI expressions. 
- The onboarding accent-color grid was a deeply nested expression that triggered the compiler timeout; splitting it into smaller parts improves type-checking performance.

### Description
- Renamed the centralized haptics helper from `Haptics` to `HapticFeedback` and moved the file to `Craftify/HapticFeedback.swift`, keeping the prepared `selection()`, `impact(_:)`, and `notification(_:)` generators on the `@MainActor` enum.
- Replaced all call sites across the codebase to use `HapticFeedback.*` instead of `Haptics.*` to remove the symbol ambiguity. 
- Refactored `OnboardingView` by extracting the inline accent-color grid into `accentColorPicker`, `accentColorButton(for:)`, and `selectAccentColor(_:)` helpers so the view is expressed as smaller sub-expressions and calls `HapticFeedback.selection()` from a single action function. 
- Minor tidy-ups to call sites in other views (`ContentView`, `MoreView`, `FavoritesView`, `RecipeDetailView`, `RecipeSearchView`, `ReportRecipeView`, `SupportView`, `AppAppearanceView`) to use the new helper name.

### Testing
- Ran `git diff --cached --check` and confirmed there are no staged whitespace or obvious patch issues. 
- Verified there are no remaining `Haptics.` call sites with `rg -n '\bHaptics\.' Craftify --glob '*.swift'`. 
- Confirmed the updated `HapticFeedback` references across Swift files with ripgrep and inspected the diffs. 
- Could not run an iOS build (`xcodebuild`) in this environment because `xcodebuild` is unavailable on the host, so no compilation was performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a654e1702f08320839c468866c5bcf6)