### PR TITLE
Polish onboarding transition and restore About button styling

### DIFF
--- a/Craftify/CraftifyApp.swift
+++ b/Craftify/CraftifyApp.swift
@@ -28,8 +28,6 @@ struct CraftifyApp: App {
     @StateObject private var dataManager = DataManager()
     @AppStorage("hasLaunchedBefore") private var hasLaunchedBefore: Bool = false
     @State private var showOnboarding: Bool = false
-    @State private var onboardingOpacity: CGFloat = 1.0
-    @State private var onboardingOffset: CGFloat = 0.0
 
     var body: some Scene {
         WindowGroup {
@@ -45,16 +43,8 @@ struct CraftifyApp: App {
                         errorMessage: $dataManager.errorMessage,
                         isFirstLaunch: !hasLaunchedBefore,
                         onDismiss: {
-                            withAnimation(.easeInOut(duration: 0.5)) {
-                                onboardingOpacity = 0.0
-                                onboardingOffset = -UIScreen.main.bounds.height
-                            }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                                hasLaunchedBefore = true
-                                showOnboarding = false
-                                onboardingOpacity = 1.0
-                                onboardingOffset = 0.0
-                            }
+                            hasLaunchedBefore = true
+                            showOnboarding = false
                         },
                         onRetry: {
                             dataManager.fetchRecipes(isManual: false)
@@ -69,8 +59,6 @@ struct CraftifyApp: App {
                                 .ignoresSafeArea()
                         }
                     }
-                    .opacity(onboardingOpacity)
-                    .offset(y: onboardingOffset)
                     .zIndex(1)
                 }
             }

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -335,8 +335,9 @@ struct AboutView: View {
             .accessibilityLabel("Craftify for Minecraft, \(appVersion). Craftify helps you manage your recipes and favorites.")
             .accessibilityHint("About the Craftify app and its purpose")
             
-            VStack(spacing: 0) {
-                NavigationLink(destination: AppAppearanceView()) {
+            List {
+                Section {
+                    NavigationLink(destination: AppAppearanceView()) {
                         buttonStyle(title: "App Appearance", systemImage: "app.badge.fill")
                     }
                     .simultaneousGesture(TapGesture().onEnded {
@@ -352,10 +353,7 @@ struct AboutView: View {
                     .accessibilityLabel("App Appearance")
                     .accessibilityHint("Customize the app's icon and appearance settings")
 
-                Divider()
-                    .padding(.leading, 44)
-
-                NavigationLink(destination: ReleaseNotesView()) {
+                    NavigationLink(destination: ReleaseNotesView()) {
                         buttonStyle(title: "Release Notes", systemImage: "doc.text.fill")
                     }
                     .simultaneousGesture(TapGesture().onEnded {
@@ -370,8 +368,14 @@ struct AboutView: View {
                     ))
                     .accessibilityLabel("Release Notes")
                     .accessibilityHint("View the release notes for Craftify")
+                }
             }
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .scrollDisabled(true)
+            .frame(height: dynamicTypeSize.isAccessibilitySize
+                ? 220
+                : (horizontalSizeClass == .regular ? 154 : 126))
             .padding(.horizontal, horizontalSizeClass == .regular ? 12 : 8)
             
             NavigationLink(destination: SupportView()) {

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -40,6 +40,10 @@ struct OnboardingView: View {
         .id(accentColorPreference)
         .tint(Color.userAccentColor)
         .dynamicTypeSize(.xSmall ... .accessibility5)
+        .mask {
+            SlidingDoorMask(progress: isFinishing && !reduceMotion ? 1 : 0)
+                .ignoresSafeArea()
+        }
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.35), value: isLoading)
         .animation(reduceMotion ? nil : .easeInOut(duration: 0.35), value: errorMessage)
         .sensoryFeedback(.impact(weight: .light), trigger: step)
@@ -173,8 +177,6 @@ struct OnboardingView: View {
             .padding(.bottom, 18)
         }
         .frame(maxWidth: 720)
-        .opacity(isFinishing ? 0 : 1)
-        .offset(y: isFinishing && !reduceMotion ? -24 : 0)
     }
 
     private var appMark: AppMark {
@@ -193,8 +195,18 @@ struct OnboardingView: View {
 
     private func finishOnboarding() {
         guard !isFinishing else { return }
-        isFinishing = true
-        onDismiss()
+        guard !reduceMotion else {
+            isFinishing = true
+            onDismiss()
+            return
+        }
+
+        withAnimation(.smooth(duration: 0.75)) {
+            isFinishing = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
+            onDismiss()
+        }
     }
 }
 
@@ -260,8 +272,12 @@ private struct OnboardingPageView: View {
 
                 if page.title == "Keep favorites close" {
                     VStack(alignment: .leading, spacing: 12) {
-                        Label("Choose an appearance that feels like yours", systemImage: "paintpalette.fill")
-                            .font(.subheadline.weight(.semibold))
+                        HStack(spacing: 8) {
+                            Image(systemName: "paintpalette.fill")
+                                .foregroundStyle(Color.userAccentColor)
+                            Text("Choose an appearance that feels like yours")
+                        }
+                        .font(.subheadline.weight(.semibold))
 
                         accentColorPicker
                     }
@@ -312,6 +328,24 @@ private struct OnboardingPageView: View {
     private func selectAccentColor(_ id: String) {
         accentColorPreference = id
         HapticFeedback.selection()
+    }
+}
+
+private struct SlidingDoorMask: Shape {
+    var progress: CGFloat
+
+    var animatableData: CGFloat {
+        get { progress }
+        set { progress = newValue }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        let halfWidth = rect.width / 2
+        let travel = halfWidth * progress
+        var path = Path()
+        path.addRect(CGRect(x: -travel, y: rect.minY, width: halfWidth, height: rect.height))
+        path.addRect(CGRect(x: halfWidth + travel, y: rect.minY, width: halfWidth, height: rect.height))
+        return path
     }
 }
 


### PR DESCRIPTION
### Motivation

- Make the onboarding dismissal feel more polished by revealing the main app with a center-opening sliding-door animation when the user taps `Start Crafting` while respecting the user's Reduce Motion setting. 
- Ensure the appearance selection UI in onboarding uses the app accent color for its icon so the palette reflects the chosen accent. 
- Revert the About actions to a cleaner inset-grouped button layout and remove the nested scrolling behavior that caused visual/scrolling issues.

### Description

- Added a `SlidingDoorMask` `Shape` and applied it as a `mask` to `OnboardingView` to create a center-opening sliding-door reveal, and updated `finishOnboarding()` to animate and delay `onDismiss()` when Reduce Motion is not enabled. 
- Replaced the `Label` in the onboarding appearance block with an `HStack` that uses `Color.userAccentColor` for the `paintpalette.fill` icon so it now respects the selected accent. 
- Removed the previous whole-screen upward fade/offset dismissal in `CraftifyApp` and simplified onboarding teardown so the new mask animation is the visible transition. 
- Restored the inset-grouped style for the About action buttons by using a `List` + `Section`, disabled list scrolling with `.scrollDisabled(true)`, hid the scroll background with `.scrollContentBackground(.hidden)`, and added an adaptive fixed height that grows when `dynamicTypeSize.isAccessibilitySize` is active to avoid truncation/scroll issues.

### Testing

- Ran `git diff --check` and local repository checks to validate there are no obvious diff conflicts or whitespace issues, which completed successfully. 
- Verified file diffs and local status with `git status` to confirm the intended files were updated, which completed successfully. 
- Attempted to run `xcodebuild` for a simulator build, but Xcode is not available in this Linux environment so the full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a654ff69cb0832082d426557843ec2b)