### PR TITLE
Polish recipe sync and onboarding experiences

### DIFF
--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -44,8 +44,8 @@ struct OnboardingView: View {
             SlidingDoorMask(progress: isFinishing && !reduceMotion ? 1 : 0)
                 .ignoresSafeArea()
         }
-        .animation(reduceMotion ? nil : .easeInOut(duration: 0.35), value: isLoading)
-        .animation(reduceMotion ? nil : .easeInOut(duration: 0.35), value: errorMessage)
+        .animation(pageAnimation, value: isLoading)
+        .animation(pageAnimation, value: errorMessage)
         .sensoryFeedback(.impact(weight: .light), trigger: step)
         .sensoryFeedback(.success, trigger: isFinishing)
         .onChange(of: isLoading) { _, loading in
@@ -145,7 +145,7 @@ struct OnboardingView: View {
                         Capsule()
                             .fill(index == step ? Color.userAccentColor : Color.secondary.opacity(0.22))
                             .frame(width: index == step ? 28 : 8, height: 8)
-                            .animation(reduceMotion ? nil : .snappy, value: step)
+                            .animation(pageAnimation, value: step)
                     }
                 }
                 .accessibilityHidden(true)
@@ -187,8 +187,12 @@ struct OnboardingView: View {
         horizontalSizeClass == .regular ? 48 : 24
     }
 
+    private var pageAnimation: Animation? {
+        reduceMotion ? nil : .easeInOut(duration: 0.55)
+    }
+
     private func move(to newStep: Int) {
-        withAnimation(reduceMotion ? nil : .snappy(duration: 0.35)) {
+        withAnimation(pageAnimation) {
             step = newStep
         }
     }
@@ -201,10 +205,10 @@ struct OnboardingView: View {
             return
         }
 
-        withAnimation(.smooth(duration: 0.75)) {
+        withAnimation(.easeInOut(duration: 0.9)) {
             isFinishing = true
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.9) {
             onDismiss()
         }
     }
@@ -232,11 +236,12 @@ private struct OnboardingPageView: View {
                     Image(systemName: page.symbol)
                         .font(.system(size: 66, weight: .medium))
                         .foregroundStyle(Color.userAccentColor.gradient)
-                        .symbolEffect(.bounce, value: isCurrent)
                 }
                 .frame(width: 176, height: 176)
                 .shadow(color: Color.userAccentColor.opacity(0.14), radius: 24, y: 12)
-                .scaleEffect(isCurrent || reduceMotion ? 1 : 0.9)
+                .scaleEffect(isCurrent || reduceMotion ? 1 : 0.94)
+                .opacity(isCurrent || reduceMotion ? 1 : 0.7)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.55), value: isCurrent)
 
                 VStack(spacing: 10) {
                     Text(page.eyebrow.uppercased())
@@ -272,12 +277,15 @@ private struct OnboardingPageView: View {
 
                 if page.title == "Keep favorites close" {
                     VStack(alignment: .leading, spacing: 12) {
-                        HStack(spacing: 8) {
+                        HStack(spacing: 14) {
                             Image(systemName: "paintpalette.fill")
+                                .font(.headline)
                                 .foregroundStyle(Color.userAccentColor)
+                                .frame(width: 28)
                             Text("Choose an appearance that feels like yours")
+                                .frame(maxWidth: .infinity, alignment: .leading)
                         }
-                        .font(.subheadline.weight(.semibold))
+                        .font(.subheadline.weight(.medium))
 
                         accentColorPicker
                     }
@@ -294,13 +302,14 @@ private struct OnboardingPageView: View {
     }
 
     private var accentColorPicker: some View {
-        let columns = [GridItem(.adaptive(minimum: 44), spacing: 12)]
+        let columns = [GridItem(.adaptive(minimum: 44), spacing: 12, alignment: .leading)]
 
         return LazyVGrid(columns: columns, spacing: 12) {
             ForEach(AppAppearanceView.accentColors) { option in
                 accentColorButton(for: option)
             }
         }
+        .padding(.leading, 42)
     }
 
     private func accentColorButton(for option: AccentColorOption) -> some View {
@@ -377,7 +386,7 @@ private struct CraftifyPrimaryButtonStyle: ButtonStyle {
             .background(Color.userAccentColor.gradient, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
             .shadow(color: Color.userAccentColor.opacity(configuration.isPressed ? 0.12 : 0.25), radius: 10, y: 5)
             .scaleEffect(configuration.isPressed ? 0.98 : 1)
-            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+            .animation(.easeInOut(duration: 0.25), value: configuration.isPressed)
     }
 }
 

--- a/Craftify/SyncOverlayView.swift
+++ b/Craftify/SyncOverlayView.swift
@@ -10,46 +10,90 @@ import SwiftUI
 struct SyncOverlayView: View {
     let horizontalSizeClass: UserInterfaceSizeClass?
     let message: String
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
-    private var cardHorizontalPadding: CGFloat {
-        horizontalSizeClass == .regular ? 100 : 40
-    }
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isAnimating = false
 
-    private var cardCornerRadius: CGFloat {
-        20
+    private var cardWidth: CGFloat {
+        horizontalSizeClass == .regular ? 420 : 330
     }
 
     var body: some View {
         ZStack {
-            Color.black.opacity(0.4)
+            Color.black.opacity(0.32)
                 .ignoresSafeArea()
 
-            VStack(spacing: 16) {
-                ProgressView()
-                    .progressViewStyle(.circular)
-                    .tint(Color.userAccentColor)
-                    .scaleEffect(1.5) // Slightly larger for visibility
+            VStack(spacing: 20) {
+                syncIllustration
 
-                Text(message)
-                    .font(.headline)
-                    .fontWeight(.semibold)
-                    .foregroundColor(.primary)
-                    .multilineTextAlignment(.center)
-                    .minimumScaleFactor(0.8)
-                    .lineLimit(2)
+                VStack(spacing: 7) {
+                    Text(message)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(.primary)
+
+                    Text("Gathering the latest recipes from your cloud cookbook.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                ProgressView()
+                    .tint(Color.userAccentColor)
+                    .controlSize(.small)
+                    .accessibilityHidden(true)
             }
-            .padding(24)
-            .background(.ultraThinMaterial) // Frosted glass blur (iOS 15+)
-            .clipShape(RoundedRectangle(cornerRadius: cardCornerRadius))
-            .shadow(color: .black.opacity(0.2), radius: 20, x: 0, y: 10)
-            .padding(.horizontal, cardHorizontalPadding)
-            .accessibilityElement(children: .contain)
-            .accessibilityLabel("\(message), Syncing in progress")
-            .accessibilityHint("Please wait while data is syncing. This overlay will dismiss automatically when complete.")
-            .accessibilityAddTraits(.isModal)
+            .padding(.horizontal, 28)
+            .padding(.vertical, 30)
+            .frame(maxWidth: cardWidth)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 26, style: .continuous)
+                    .stroke(Color.userAccentColor.opacity(0.18), lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.18), radius: 24, y: 12)
+            .padding(.horizontal, 24)
         }
-        .transition(.opacity.animation(.easeInOut(duration: 0.3))) // Smooth fade-in/out
-        .dynamicTypeSize(.xSmall ... .accessibility5)
+        .onAppear { isAnimating = true }
+        .onDisappear { isAnimating = false }
+        .transition(.opacity.combined(with: .scale(scale: 0.97)))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(message). Gathering the latest recipes from your cloud cookbook.")
+        .accessibilityHint("Please wait. This view closes automatically when syncing is complete.")
+        .accessibilityAddTraits(.isModal)
+    }
+
+    private var syncIllustration: some View {
+        ZStack {
+            Circle()
+                .fill(Color.userAccentColor.opacity(0.10))
+                .frame(width: 108, height: 108)
+                .scaleEffect(isAnimating && !reduceMotion ? 1.08 : 0.94)
+                .opacity(isAnimating && !reduceMotion ? 0.55 : 1)
+                .animation(
+                    reduceMotion ? nil : .easeInOut(duration: 1.6).repeatForever(autoreverses: true),
+                    value: isAnimating
+                )
+
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .fill(Color.userAccentColor.gradient)
+                .frame(width: 76, height: 76)
+                .shadow(color: Color.userAccentColor.opacity(0.24), radius: 14, y: 7)
+
+            Image(systemName: "book.closed.fill")
+                .font(.system(size: 32, weight: .semibold))
+                .foregroundStyle(.white)
+
+            Image(systemName: "icloud.fill")
+                .font(.system(size: 19, weight: .semibold))
+                .foregroundStyle(Color.userAccentColor, Color(.systemBackground))
+                .padding(7)
+                .background(.regularMaterial, in: Circle())
+                .offset(x: 35, y: 35)
+                .scaleEffect(isAnimating && !reduceMotion ? 1 : 0.88)
+                .animation(reduceMotion ? nil : .easeInOut(duration: 0.7), value: isAnimating)
+        }
+        .frame(width: 116, height: 116)
+        .accessibilityHidden(true)
     }
 }


### PR DESCRIPTION
### Motivation
- Improve the manual CloudKit sync overlay so it matches the app’s visual language and provides clearer, calmer feedback while syncing.
- Make the onboarding flow feel cohesive by smoothing animations, respecting Reduce Motion, and aligning the appearance picker layout with other page content.

### Description
- Rebuilt `SyncOverlayView` as a responsive, cookbook-styled card with an accented material background, a cookbook + iCloud illustration, gentle repeating animations that respect `accessibilityReduceMotion`, improved accessibility labels/hints, and a subtler scale/opacity transition on show/hide.
- Added a local `syncIllustration` view inside `SyncOverlayView` and wired `isAnimating` so the artwork animates when visible while avoiding motion when the user requests reduced motion.
- Introduced `pageAnimation` in `OnboardingView` and replaced multiple ad-hoc timing values with this single easing to slow and unify page, indicator, and dismissal animations, and extended the final dismissal timing for a smoother finish.
- Replaced the abrupt symbol bounce with a softer scale+fade treatment, softened scale/opacity values for off-screen pages, adjusted `CraftifyPrimaryButtonStyle` animation to `easeInOut(duration: 0.25)`, and realigned the appearance picker label and grid spacing so the color swatches sit visually under the label.

### Testing
- Parsed the modified Swift files with `swiftc -frontend -parse Craftify/SyncOverlayView.swift Craftify/OnboardingView.swift` and the parse completed successfully.
- Checked repository diffs with `git diff --check` and no whitespace/error issues were reported.
- Validated `Craftify/Info.plist` with Python `plistlib` (loaded successfully) to ensure the bundle plist remains valid.
- Note: a full iOS build or simulator run was not performed because Xcode is not available in this Linux environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a669d53e1b88320b4a5bd8dbb09cff6)