### PR TITLE
Fix Section initializers in MoreView

### DIFF
--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -29,15 +29,17 @@ struct MoreView: View {
                     }
                 }
 
-                Section("Craftify") {
+                Section {
                     destination("About Craftify", systemImage: "info.circle.fill", hint: "View app information, appearance, release notes, support, and privacy") {
                         AboutView()
                     }
+                } header: {
+                    Text("Craftify")
                 } footer: {
                     Text("Craftify for Minecraft is an independent app and is not approved by or associated with Mojang or Microsoft.")
                 }
 
-                Section("Data Sync") {
+                Section {
                     Button(action: syncRecipes) {
                         Label {
                             VStack(alignment: .leading, spacing: 3) {
@@ -66,6 +68,8 @@ struct MoreView: View {
                     }
 
                     LabeledContent("Recipes", value: dataManager.recipes.count.formatted())
+                } header: {
+                    Text("Data Sync")
                 } footer: {
                     if remainingCooldownTime > 0 {
                         Text("Sync is available again in \(remainingCooldownTime) second\(remainingCooldownTime == 1 ? "" : "s").")


### PR DESCRIPTION
### Motivation
- The previous use of the `Section("Title")` initializer with footers caused SwiftUI generic inference and call-site ambiguity, producing compile errors in `MoreView.swift`.

### Description
- Replace the ambiguous `Section("Craftify")` and `Section("Data Sync")` forms with explicit `Section { ... } header: { Text("...") } footer: { ... }` closures to separate content, header, and footer while preserving existing footer text and behavior.

### Testing
- Ran `swiftc -frontend -parse Craftify/MoreView.swift` and parsing succeeded.
- Ran `git diff --check` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69202f2a7c83209c0ea6539c11d637)