### PR TITLE
Refine accent colors and grouped view backgrounds

### DIFF
--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -23,7 +23,7 @@ struct ContentView: View {
     var body: some View {
         ZStack {
             // 1) solid base so the TabView never floats transparent
-            Color(.systemBackground)
+            Color(.systemGroupedBackground)
                 .ignoresSafeArea()
 
             // 2) your TabView

--- a/Craftify/CraftifyApp.swift
+++ b/Craftify/CraftifyApp.swift
@@ -27,6 +27,7 @@ struct CraftifyApp: App {
 
     @StateObject private var dataManager = DataManager()
     @AppStorage("hasLaunchedBefore") private var hasLaunchedBefore: Bool = false
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
     @State private var showOnboarding: Bool = false
 
     var body: some Scene {
@@ -62,6 +63,8 @@ struct CraftifyApp: App {
                     .zIndex(1)
                 }
             }
+            .id(accentColorPreference)
+            .tint(Color.userAccentColor)
             .dynamicTypeSize(.xSmall ... .accessibility5)
             .accessibilityElement(children: .contain)
             .accessibilityLabel("Craftify App")

--- a/Craftify/FavoritesView.swift
+++ b/Craftify/FavoritesView.swift
@@ -205,6 +205,7 @@ struct FavoritesView: View {
                     favoritesContent
                 }
             }
+            .background(Color(.systemGroupedBackground))
             .id(accentColorPreference)
             .navigationTitle("Favorite Recipes")
             .navigationBarTitleDisplayMode(.large)
@@ -419,7 +420,7 @@ struct FavoritesView: View {
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(.systemBackground))
+        .background(Color(.systemGroupedBackground))
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Loading Favorites")
         .accessibilityHint(

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MoreView: View {
     @EnvironmentObject private var dataManager: DataManager
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
     @State private var cooldownTask: Task<Void, Never>?
     @State private var remainingCooldownTime = 0
 
@@ -56,7 +57,10 @@ struct MoreView: View {
                                 Image(systemName: "arrow.clockwise")
                             }
                         }
+                        .frame(maxWidth: .infinity, alignment: .center)
                     }
+                    .buttonStyle(.borderedProminent)
+                    .tint(Color.userAccentColor)
                     .disabled(dataManager.isLoading || !dataManager.isConnected || remainingCooldownTime > 0)
                     .accessibilityHint(syncHint)
 
@@ -64,7 +68,13 @@ struct MoreView: View {
                         Text(dataManager.isConnected ? "Online" : "Offline")
                             .foregroundStyle(dataManager.isConnected ? .green : .red)
                     } label: {
-                        Label("Connection", systemImage: dataManager.isConnected ? "wifi" : "wifi.slash")
+                        Label {
+                            Text("Connection")
+                                .foregroundStyle(.primary)
+                        } icon: {
+                            Image(systemName: dataManager.isConnected ? "wifi" : "wifi.slash")
+                                .foregroundStyle(Color.userAccentColor)
+                        }
                     }
 
                     LabeledContent("Recipes", value: dataManager.recipes.count.formatted())
@@ -80,8 +90,11 @@ struct MoreView: View {
                 }
             }
             .listStyle(.insetGrouped)
+            .listSectionSpacing(24)
             .scrollContentBackground(.hidden)
-            .background(Color(.systemBackground))
+            .background(Color(.systemGroupedBackground))
+            .id(accentColorPreference)
+            .tint(Color.userAccentColor)
             .navigationTitle("More")
             .navigationBarTitleDisplayMode(.large)
             .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
@@ -118,8 +131,13 @@ struct MoreView: View {
         @ViewBuilder destination: () -> Destination
     ) -> some View {
         NavigationLink(destination: destination()) {
-            Label(title, systemImage: systemImage)
-                .foregroundStyle(.primary)
+            Label {
+                Text(title)
+                    .foregroundStyle(.primary)
+            } icon: {
+                Image(systemName: systemImage)
+                    .foregroundStyle(Color.userAccentColor)
+            }
         }
         .accessibilityHint(hint)
     }
@@ -159,6 +177,7 @@ struct MoreView: View {
 
 struct AboutView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
 
     private var appVersion: String {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
@@ -193,17 +212,23 @@ struct AboutView: View {
             }
 
             Section("Personalize") {
-                NavigationLink("App Appearance", destination: AppAppearanceView())
+                NavigationLink(destination: AppAppearanceView()) {
+                    accentLabel("App Appearance", systemImage: "paintpalette.fill")
+                }
             }
 
             Section("Information") {
-                NavigationLink("Release Notes", destination: ReleaseNotesView())
-                NavigationLink("Support & Privacy", destination: SupportView())
+                NavigationLink(destination: ReleaseNotesView()) {
+                    accentLabel("Release Notes", systemImage: "sparkles")
+                }
+                NavigationLink(destination: SupportView()) {
+                    accentLabel("Support & Privacy", systemImage: "hand.raised.fill")
+                }
             }
 
             Section("Acknowledgements") {
                 Link(destination: URL(string: "https://minecraft.wiki/")!) {
-                    Label("Minecraft Wiki", systemImage: "arrow.up.right.square")
+                    accentLabel("Minecraft Wiki", systemImage: "arrow.up.right.square")
                 }
                 Text("Thank you to the Minecraft Wiki contributors for the recipe knowledge and thumbnails that help power Craftify.")
                     .font(.footnote)
@@ -218,9 +243,21 @@ struct AboutView: View {
         }
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
-        .background(Color(.systemBackground))
+        .background(Color(.systemGroupedBackground))
+        .id(accentColorPreference)
+        .tint(Color.userAccentColor)
         .navigationTitle("About Craftify")
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(.large)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+    }
+
+    private func accentLabel(_ title: String, systemImage: String) -> some View {
+        Label {
+            Text(title)
+                .foregroundStyle(.primary)
+        } icon: {
+            Image(systemName: systemImage)
+                .foregroundStyle(Color.userAccentColor)
+        }
     }
 }

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -56,7 +56,7 @@ struct OnboardingView: View {
 
     private var onboardingBackground: some View {
         ZStack {
-            Color(.systemBackground)
+            Color(.systemGroupedBackground)
             LinearGradient(
                 colors: [Color.userAccentColor.opacity(0.22), .clear, Color.userAccentColor.opacity(0.08)],
                 startPoint: .topLeading,

--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -39,7 +39,7 @@ struct RecipeDetailView: View {
 
     var body: some View {
         ZStack {
-            Color(.systemBackground)
+            Color(.systemGroupedBackground)
 
             RecipeDetailContent(
                 recipe: recipe,

--- a/Craftify/RecipeSearchView.swift
+++ b/Craftify/RecipeSearchView.swift
@@ -274,7 +274,7 @@ struct RecipeSearchView: View {
                             .foregroundColor(.secondary)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color(.systemBackground))
+                    .background(Color(.systemGroupedBackground))
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Loading Recipes")
                     .accessibilityHint("Please wait while the recipes are being loaded")

--- a/Craftify/ReleaseNotesView.swift
+++ b/Craftify/ReleaseNotesView.swift
@@ -58,9 +58,14 @@ struct ReleaseNotesView: View {
                             .font(.headline)
                             .foregroundColor(.secondary)) {
                     ForEach(note.changes, id: \.self) { change in
-                        Label(change, systemImage: "checkmark.circle.fill")
+                        Label {
+                            Text(change)
+                                .foregroundStyle(.primary)
+                        } icon: {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundStyle(Color.userAccentColor)
+                        }
                             .font(.body)
-                            .foregroundStyle(.primary)
                             .padding(.vertical, horizontalSizeClass == .regular ? listRowPaddingVertical * 1.5 : listRowPaddingVertical)
                             .accessibilityLabel(change)
                     }
@@ -70,7 +75,7 @@ struct ReleaseNotesView: View {
         .id(accentColorPreference)
         .listStyle(InsetGroupedListStyle())
         .scrollContentBackground(.hidden)
-        .background(Color(.systemBackground))
+        .background(Color(.systemGroupedBackground))
         .navigationTitle("Release Notes")
         .navigationBarTitleDisplayMode(.large)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)

--- a/Craftify/SyncOverlayView.swift
+++ b/Craftify/SyncOverlayView.swift
@@ -86,7 +86,7 @@ struct SyncOverlayView: View {
 
             Image(systemName: "icloud.fill")
                 .font(.system(size: 19, weight: .semibold))
-                .foregroundStyle(Color.userAccentColor, Color(.systemBackground))
+                .foregroundStyle(Color.userAccentColor, Color(.systemGroupedBackground))
                 .padding(7)
                 .background(.regularMaterial, in: Circle())
                 .offset(x: 35, y: 35)


### PR DESCRIPTION
### Motivation
- Reapply the user-selected accent color preference across the UI so symbols and interactive controls follow `AppAppearanceView` again.
- Make the manual recipe sync affordance clearer and consistent with other primary actions by converting it into a prominent button.
- Improve light-mode contrast and visual consistency by using the grouped background surface that `SupportView` uses, and normalize section spacing in `MoreView`.
- Ensure the `About` screen uses the same large navigation title style as other screens for consistency.

### Description
- Use the user accent throughout the app by reading `@AppStorage("accentColorPreference")` where needed, adding `.id(accentColorPreference)` and applying `.tint(Color.userAccentColor)` at top-level views for immediate refresh when the preference changes.
- Restyled the sync control in `MoreView` into a full-width prominent button using `.buttonStyle(.borderedProminent)` and `.tint(Color.userAccentColor)`, and centered its label with `frame(maxWidth: .infinity, alignment: .center)` to improve affordance and accessibility.
- Updated navigation labels and inline symbols to honor the accent by switching symbol `foregroundStyle` to `Color.userAccentColor` and replacing plain `Label(title, systemImage:)` usages with labeled variants that set icon tint explicitly via a small helper (`accentLabel`) in `MoreView`/`AboutView`/`ReleaseNotesView`.
- Standardized backgrounds to `Color(.systemGroupedBackground)` (from `systemBackground`) on multiple top-level and loading surfaces to match `SupportView` and improve light-mode button contrast, and added `.listSectionSpacing(24)` to `MoreView` to equalize spacing between sections.
- Set the `AboutView` navigation title display mode to `.large` for parity with other screens.
- Files updated include `MoreView.swift`, `AboutView` (in `MoreView.swift`), `ReleaseNotesView.swift`, `ContentView.swift`, `FavoritesView.swift`, `RecipeDetailView.swift`, `RecipeSearchView.swift`, `OnboardingView.swift`, `SyncOverlayView.swift`, and `CraftifyApp.swift`.

### Testing
- Ran `git diff --check` which reported no trailing whitespace or index issues and showed the intended changes.
- Verified repository status with `git status --short --branch` and observed the updated files staged and committed locally.
- Attempted an `xcodebuild` invocation to validate a simulator build, but `xcodebuild` is not available in the execution environment so a full build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6943e5fe908320bf15984b651d9cd0)