### PR TITLE
Refine More navigation, sync UI, and screen backgrounds

### DIFF
--- a/Craftify/AppAppearanceView.swift
+++ b/Craftify/AppAppearanceView.swift
@@ -134,7 +134,7 @@ struct AppAppearanceView: View {
         }
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
-        .background(Color(.systemBackground))
+        .background(Color(.systemGroupedBackground))
         .navigationTitle("App Appearance")
         .navigationBarTitleDisplayMode(.large)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -152,7 +152,7 @@ struct RecipesTabView: View {
                             .foregroundColor(.secondary)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color(.systemBackground))
+                    .background(Color(.systemGroupedBackground))
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Loading Recipes")
                     .accessibilityHint("Please wait while the recipes are being loaded")
@@ -343,7 +343,7 @@ struct RecipeListView: View {
                         CraftifyPicksHeader(isExpanded: isCraftifyPicksExpanded, accentColorPreference: accentColorPreference) {
                             withAnimation { isCraftifyPicksExpanded.toggle() }
                         }
-                        .background(Color(.systemBackground))
+                        .background(Color(.systemGroupedBackground))
                     }
                 }
 
@@ -389,7 +389,7 @@ struct RecipeListView: View {
                             .padding(.horizontal, horizontalSizeClass == .regular ? paddingHorizontal * 1.5 : paddingHorizontal)
                             .padding(.vertical, paddingVertical)
                             .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color(.systemBackground))
+                            .background(Color(.systemGroupedBackground))
                     }
                 }
             }
@@ -533,7 +533,7 @@ struct CraftifyPicksHeader: View {
         }
         .padding(.horizontal, horizontalSizeClass == .regular ? paddingHorizontal * 1.5 : paddingHorizontal)
         .padding(.vertical, paddingVertical)
-        .background(Color(.systemBackground))
+        .background(Color(.systemGroupedBackground))
         .frame(height: horizontalSizeClass == .regular ? headerHeightRegular : headerHeightCompact)
         .dynamicTypeSize(.xSmall ... .accessibility5)
     }

--- a/Craftify/CraftifyApp.swift
+++ b/Craftify/CraftifyApp.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import UIKit
+import Combine
 
 @main
 struct CraftifyApp: App {
@@ -63,7 +64,6 @@ struct CraftifyApp: App {
                     .zIndex(1)
                 }
             }
-            .id(accentColorPreference)
             .tint(Color.userAccentColor)
             .dynamicTypeSize(.xSmall ... .accessibility5)
             .accessibilityElement(children: .contain)
@@ -75,8 +75,15 @@ struct CraftifyApp: App {
                 }
                 print("CraftifyApp: DataManager initialized, isLoading: \(dataManager.isLoading)")
             }
+            .onReceive(NotificationCenter.default.publisher(for: .showOnboarding)) { _ in
+                showOnboarding = true
+            }
         }
     }
+}
+
+extension Notification.Name {
+    static let showOnboarding = Notification.Name("showOnboarding")
 }
 
 // Helper view for iOS 26 vibrancy effect

--- a/Craftify/FavoritesView.swift
+++ b/Craftify/FavoritesView.swift
@@ -121,7 +121,7 @@ struct FavoritesSection: View {
                     )
                     .padding(.vertical, paddingVertical)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color(.systemBackground))
+                    .background(Color(.systemGroupedBackground))
             }
         }
         .dynamicTypeSize(.xSmall ... .accessibility5)
@@ -405,7 +405,7 @@ struct FavoritesView: View {
                     isCraftifyPicksExpanded.toggle()
                 }
             }
-            .background(Color(.systemBackground))
+            .background(Color(.systemGroupedBackground))
         }
     }
 

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -31,24 +31,49 @@ struct MoreView: View {
                 }
 
                 Section {
+                    destination("App Appearance", systemImage: "paintpalette.fill", hint: "Choose the app icon, color, and appearance") {
+                        AppAppearanceView()
+                    }
+                    Button {
+                        NotificationCenter.default.post(name: .showOnboarding, object: nil)
+                    } label: {
+                        Label {
+                            Text("Getting Started")
+                                .foregroundStyle(.primary)
+                        } icon: {
+                            Image(systemName: "lightbulb.fill")
+                                .foregroundStyle(Color.userAccentColor)
+                        }
+                    }
+                    .accessibilityHint("Revisit Craftify's introductory tips")
                     destination("About Craftify", systemImage: "info.circle.fill", hint: "View app information, appearance, release notes, support, and privacy") {
                         AboutView()
                     }
                 } header: {
                     Text("Craftify")
-                } footer: {
-                    Text("Craftify for Minecraft is an independent app and is not approved by or associated with Mojang or Microsoft.")
                 }
 
                 Section {
+                    HStack(spacing: 16) {
+                        syncStatusItem(
+                            dataManager.isConnected ? "Online" : "Offline",
+                            systemImage: dataManager.isConnected ? "wifi" : "wifi.slash",
+                            color: dataManager.isConnected ? .green : .red
+                        )
+                        syncStatusItem(
+                            "\(dataManager.recipes.count.formatted()) recipes",
+                            systemImage: "book.closed.fill"
+                        )
+                        Spacer(minLength: 0)
+                        Text(syncDetail)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.trailing)
+                    }
+
                     Button(action: syncRecipes) {
                         Label {
-                            VStack(alignment: .leading, spacing: 3) {
-                                Text(dataManager.isLoading ? "Syncing Recipes…" : "Sync Recipes")
-                                Text(syncDetail)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
+                            Text(dataManager.isLoading ? "Checking for Updates…" : "Check for Recipe Updates")
                         } icon: {
                             if dataManager.isLoading {
                                 ProgressView()
@@ -63,21 +88,6 @@ struct MoreView: View {
                     .tint(Color.userAccentColor)
                     .disabled(dataManager.isLoading || !dataManager.isConnected || remainingCooldownTime > 0)
                     .accessibilityHint(syncHint)
-
-                    LabeledContent {
-                        Text(dataManager.isConnected ? "Online" : "Offline")
-                            .foregroundStyle(dataManager.isConnected ? .green : .red)
-                    } label: {
-                        Label {
-                            Text("Connection")
-                                .foregroundStyle(.primary)
-                        } icon: {
-                            Image(systemName: dataManager.isConnected ? "wifi" : "wifi.slash")
-                                .foregroundStyle(Color.userAccentColor)
-                        }
-                    }
-
-                    LabeledContent("Recipes", value: dataManager.recipes.count.formatted())
                 } header: {
                     Text("Data Sync")
                 } footer: {
@@ -93,7 +103,6 @@ struct MoreView: View {
             .listSectionSpacing(24)
             .scrollContentBackground(.hidden)
             .background(Color(.systemGroupedBackground))
-            .id(accentColorPreference)
             .tint(Color.userAccentColor)
             .navigationTitle("More")
             .navigationBarTitleDisplayMode(.large)
@@ -122,6 +131,13 @@ struct MoreView: View {
             get: { dataManager.errorMessage != nil },
             set: { if !$0 { dataManager.errorMessage = nil } }
         )
+    }
+
+    private func syncStatusItem(_ title: String, systemImage: String, color: Color = .secondary) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(.caption2)
+            .foregroundStyle(color)
+            .lineLimit(1)
     }
 
     private func destination<Destination: View>(
@@ -211,12 +227,6 @@ struct AboutView: View {
                 .accessibilityElement(children: .combine)
             }
 
-            Section("Personalize") {
-                NavigationLink(destination: AppAppearanceView()) {
-                    accentLabel("App Appearance", systemImage: "paintpalette.fill")
-                }
-            }
-
             Section("Information") {
                 NavigationLink(destination: ReleaseNotesView()) {
                     accentLabel("Release Notes", systemImage: "sparkles")
@@ -244,7 +254,6 @@ struct AboutView: View {
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
         .background(Color(.systemGroupedBackground))
-        .id(accentColorPreference)
         .tint(Color.userAccentColor)
         .navigationTitle("About Craftify")
         .navigationBarTitleDisplayMode(.large)

--- a/Craftify/RecipeSearchView.swift
+++ b/Craftify/RecipeSearchView.swift
@@ -136,7 +136,7 @@ struct RecipeSearchView: View {
                                 .padding(.horizontal, 16)
                                 .padding(.top, 8)
                                 .padding(.bottom, 4)
-                                .background(Color(.systemBackground))
+                                .background(Color(.systemGroupedBackground))
                                 .id(accentColorPreference)
 
                                 RecentSearchesList(
@@ -252,7 +252,7 @@ struct RecipeSearchView: View {
                                             .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
                                             .padding(.vertical, 8)
                                             .frame(maxWidth: .infinity, alignment: .leading)
-                                            .background(Color(.systemBackground))
+                                            .background(Color(.systemGroupedBackground))
                                     }
                                 }
                             }
@@ -260,6 +260,7 @@ struct RecipeSearchView: View {
                     }
                 }
                 .scrollContentBackground(.hidden)
+                .background(Color(.systemGroupedBackground))
                 .safeAreaInset(edge: .bottom, content: { Color.clear.frame(height: 0) })
             }
             .id(accentColorPreference)


### PR DESCRIPTION
### Motivation
- Improve discoverability and usability of the More screen by moving appearance controls into the main Craftify section and offering a quick way to reopen onboarding tips. 
- Prevent app appearance changes from forcing navigation resets and fix contrast/visibility issues that made controls vanish in light mode. 
- Clarify the Data Sync area so the call-to-action and the small status metadata are visually distinct and easier to scan.

### Description
- Moved the `AppAppearanceView` link into the main "Craftify" section in `MoreView.swift` and added a "Getting Started" button that posts a `Notification` to reopen the onboarding flow instead of rebuilding navigation state. (See `MoreView.swift` and `CraftifyApp.swift`.)
- Redesigned the Data Sync section in `MoreView.swift` to show compact connection / recipe-count / last-sync metadata as small, secondary text and replaced the sync button label with a clearer `Check for Recipe Updates` action; introduced `syncStatusItem` helper for compact status items. 
- Removed the in-section disclaimer text and replaced it with the Getting Started action to revisit `OnboardingView`. 
- Standardized background usage across screens (switched several `Color(.systemBackground)` occurrences to `Color(.systemGroupedBackground)`) to fix visibility in light mode for `AppAppearanceView.swift`, `ContentView.swift`, `FavoritesView.swift`, and `RecipeSearchView.swift`. 
- Added an app-level `Notification` handler (`Notification.Name.showOnboarding`) in `CraftifyApp.swift` so the Getting Started button can trigger showing the existing `OnboardingView` without modifying navigation stacks; added `import Combine` where required.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff-check issues; this check passed. 
- Inspected repository status with `git status --short` to confirm the working tree reflects the intended changes; the workspace showed the updated files staged/ready. 
- Attempted to run a local Xcode build with `xcodebuild -project Craftify.xcodeproj -scheme Craftify -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO build`, but `xcodebuild` is not available in the container so a build could not be executed here (external CI or local dev machine recommended for a full build-and-test run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69f5b6b83483209f384dcacc34bc49)