### PR TITLE
Refine Craftify and Data Sync sections

### DIFF
--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -31,29 +31,40 @@ struct MoreView: View {
                 }
 
                 Section {
+                    destination("About Craftify", systemImage: "info.circle.fill", hint: "View app information, appearance, release notes, support, and privacy") {
+                        AboutView()
+                    }
                     destination("App Appearance", systemImage: "paintpalette.fill", hint: "Choose the app icon, color, and appearance") {
                         AppAppearanceView()
                     }
                     Button {
                         NotificationCenter.default.post(name: .showOnboarding, object: nil)
                     } label: {
-                        Label {
-                            Text("Getting Started")
-                                .foregroundStyle(.primary)
-                        } icon: {
-                            Image(systemName: "lightbulb.fill")
-                                .foregroundStyle(Color.userAccentColor)
-                        }
+                        accentLabel("Getting Started", systemImage: "lightbulb.fill")
                     }
                     .accessibilityHint("Revisit Craftify's introductory tips")
-                    destination("About Craftify", systemImage: "info.circle.fill", hint: "View app information, appearance, release notes, support, and privacy") {
-                        AboutView()
-                    }
                 } header: {
                     Text("Craftify")
                 }
 
                 Section {
+                    Button(action: syncRecipes) {
+                        Label {
+                            Text(dataManager.isLoading ? "Syncing Recipes…" : "Sync Recipes")
+                                .foregroundStyle(.primary)
+                        } icon: {
+                            if dataManager.isLoading {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Image(systemName: "arrow.clockwise")
+                                    .foregroundStyle(Color.userAccentColor)
+                            }
+                        }
+                    }
+                    .disabled(dataManager.isLoading || !dataManager.isConnected || remainingCooldownTime > 0)
+                    .accessibilityHint(syncHint)
+
                     HStack(spacing: 16) {
                         syncStatusItem(
                             dataManager.isConnected ? "Online" : "Offline",
@@ -64,30 +75,11 @@ struct MoreView: View {
                             "\(dataManager.recipes.count.formatted()) recipes",
                             systemImage: "book.closed.fill"
                         )
-                        Spacer(minLength: 0)
-                        Text(syncDetail)
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                            .multilineTextAlignment(.trailing)
                     }
 
-                    Button(action: syncRecipes) {
-                        Label {
-                            Text(dataManager.isLoading ? "Checking for Updates…" : "Check for Recipe Updates")
-                        } icon: {
-                            if dataManager.isLoading {
-                                ProgressView()
-                                    .controlSize(.small)
-                            } else {
-                                Image(systemName: "arrow.clockwise")
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .center)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(Color.userAccentColor)
-                    .disabled(dataManager.isLoading || !dataManager.isConnected || remainingCooldownTime > 0)
-                    .accessibilityHint(syncHint)
+                    Text(syncDetail)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
                 } header: {
                     Text("Data Sync")
                 } footer: {
@@ -147,15 +139,19 @@ struct MoreView: View {
         @ViewBuilder destination: () -> Destination
     ) -> some View {
         NavigationLink(destination: destination()) {
-            Label {
-                Text(title)
-                    .foregroundStyle(.primary)
-            } icon: {
-                Image(systemName: systemImage)
-                    .foregroundStyle(Color.userAccentColor)
-            }
+            accentLabel(title, systemImage: systemImage)
         }
         .accessibilityHint(hint)
+    }
+
+    private func accentLabel(_ title: String, systemImage: String) -> some View {
+        Label {
+            Text(title)
+                .foregroundStyle(.primary)
+        } icon: {
+            Image(systemName: systemImage)
+                .foregroundStyle(Color.userAccentColor)
+        }
     }
 
     private func syncRecipes() {


### PR DESCRIPTION
### Motivation
- Improve the ordering and visual consistency of the Craftify rows so the app info is easier to find. 
- Make the Getting Started action match the other navigation rows visually and accessibly. 
- Clarify the Data Sync area by separating the explicit sync action from status details so users can quickly find and trigger recipe syncs.

### Description
- Reordered the Craftify section in `MoreView.swift` to show `About Craftify`, `App Appearance`, then `Getting Started`, and replaced the custom Getting Started label with the shared `accentLabel` styling. 
- Restyled the Data Sync section so the `Sync Recipes` action appears first (now using the same link-style presentation as the Minecraft Wiki acknowledgement), followed by a non-interactive HStack with connection status and recipe count, and a separate last-synced row presented as secondary text. 
- Consolidated the accent styling by adding a local `accentLabel` helper and updated `destination(...)` to use it while preserving existing accessibility hints, cooldown logic, offline/ loading/ error handling, and `syncRecipes` behavior.

### Testing
- Ran `git diff --check` and repository status checks which completed without reported issues. 
- Confirmed the `MoreView.swift` changes compile logically in the diff and code inspection; `xcodebuild` was attempted but is unavailable in the environment so an actual build was not executed. 
- Verified that the `syncRecipes` guard, disabled states, and accessibility hints remain intact through code review of `MoreView.swift`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69f8ce76448320adf5406520edffb5)