### PR TITLE
Fix onboarding replay and Dynamic Type sync status

### DIFF
--- a/Craftify/CraftifyApp.swift
+++ b/Craftify/CraftifyApp.swift
@@ -30,6 +30,7 @@ struct CraftifyApp: App {
     @AppStorage("hasLaunchedBefore") private var hasLaunchedBefore: Bool = false
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
     @State private var showOnboarding: Bool = false
+    @State private var dismissOnboardingAfterLoading = true
 
     var body: some Scene {
         WindowGroup {
@@ -44,6 +45,7 @@ struct CraftifyApp: App {
                         isLoading: $dataManager.isLoading,
                         errorMessage: $dataManager.errorMessage,
                         isFirstLaunch: !hasLaunchedBefore,
+                        dismissAfterLoading: dismissOnboardingAfterLoading,
                         onDismiss: {
                             hasLaunchedBefore = true
                             showOnboarding = false
@@ -71,11 +73,13 @@ struct CraftifyApp: App {
             .onAppear {
                 dataManager.fetchRecipes(isManual: false)
                 if !hasLaunchedBefore {
+                    dismissOnboardingAfterLoading = true
                     showOnboarding = true
                 }
                 print("CraftifyApp: DataManager initialized, isLoading: \(dataManager.isLoading)")
             }
             .onReceive(NotificationCenter.default.publisher(for: .showOnboarding)) { _ in
+                dismissOnboardingAfterLoading = false
                 showOnboarding = true
             }
         }

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct MoreView: View {
     @EnvironmentObject private var dataManager: DataManager
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
     @State private var cooldownTask: Task<Void, Never>?
     @State private var remainingCooldownTime = 0
@@ -65,21 +66,7 @@ struct MoreView: View {
                     .disabled(dataManager.isLoading || !dataManager.isConnected || remainingCooldownTime > 0)
                     .accessibilityHint(syncHint)
 
-                    HStack(spacing: 16) {
-                        syncStatusItem(
-                            dataManager.isConnected ? "Online" : "Offline",
-                            systemImage: dataManager.isConnected ? "wifi" : "wifi.slash",
-                            color: dataManager.isConnected ? .green : .red
-                        )
-                        syncStatusItem(
-                            "\(dataManager.recipes.count.formatted()) recipes",
-                            systemImage: "book.closed.fill"
-                        )
-                    }
-
-                    Text(syncDetail)
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
+                    syncStatus
                 } header: {
                     Text("Data Sync")
                 } footer: {
@@ -116,6 +103,46 @@ struct MoreView: View {
         if !dataManager.isConnected { return "Unavailable while offline" }
         if remainingCooldownTime > 0 { return "Available in \(remainingCooldownTime) seconds" }
         return "Fetch the latest Minecraft recipes"
+    }
+
+    @ViewBuilder
+    private var syncStatus: some View {
+        if dynamicTypeSize.isAccessibilitySize {
+            VStack(alignment: .leading, spacing: 10) {
+                connectionStatus
+                recipeCountStatus
+                syncDetailText
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 16) {
+                    connectionStatus
+                    recipeCountStatus
+                }
+                syncDetailText
+            }
+        }
+    }
+
+    private var connectionStatus: some View {
+        syncStatusItem(
+            dataManager.isConnected ? "Online" : "Offline",
+            systemImage: dataManager.isConnected ? "wifi" : "wifi.slash",
+            color: dataManager.isConnected ? .green : .red
+        )
+    }
+
+    private var recipeCountStatus: some View {
+        syncStatusItem(
+            "\(dataManager.recipes.count.formatted()) recipes",
+            systemImage: "book.closed.fill"
+        )
+    }
+
+    private var syncDetailText: some View {
+        Text(syncDetail)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
     }
 
     private var errorBinding: Binding<Bool> {

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -13,6 +13,7 @@ struct OnboardingView: View {
     @Binding var isLoading: Bool
     @Binding var errorMessage: String?
     let isFirstLaunch: Bool
+    let dismissAfterLoading: Bool
     let onDismiss: () -> Void
     let onRetry: () -> Void
     let horizontalSizeClass: UserInterfaceSizeClass?
@@ -49,7 +50,7 @@ struct OnboardingView: View {
         .sensoryFeedback(.impact(weight: .light), trigger: step)
         .sensoryFeedback(.success, trigger: isFinishing)
         .onChange(of: isLoading) { _, loading in
-            guard !loading, errorMessage == nil, !isFirstLaunch else { return }
+            guard dismissAfterLoading, !loading, errorMessage == nil, !isFirstLaunch else { return }
             finishOnboarding()
         }
     }


### PR DESCRIPTION
### Motivation

- Prevent a user-requested "Getting Started" replay from being auto-dismissed by the in-flight startup recipe fetch. 
- Improve readability of the Data Sync status on compact iPhones when accessibility Dynamic Type sizes are enabled. 
- Keep the onboarding auto-dismiss behavior for the normal first-launch flow while disabling it for explicit replay requests.

### Description

- CraftifyApp: added `@State private var dismissOnboardingAfterLoading` and pass it into `OnboardingView` as `dismissAfterLoading`, setting it `true` for the automatic startup presentation and `false` when the user explicitly triggers the replay via the `showOnboarding` notification. 
- OnboardingView: added `let dismissAfterLoading: Bool` and updated the `onChange(of: isLoading)` guard so loading-driven auto-dismiss only runs when `dismissAfterLoading` is `true`. 
- MoreView: added `@Environment(\.dynamicTypeSize)` and replaced the single-row status `HStack` with a responsive `syncStatus` view that stacks `connectionStatus`, `recipeCountStatus`, and the `syncDetail` vertically at accessibility text sizes and keeps a compact HStack layout otherwise. 
- Small supporting helpers in `MoreView` added: `syncStatus`, `connectionStatus`, `recipeCountStatus`, and `syncDetailText` to keep layout logic clear and maintainable.

### Testing

- Ran `git diff --check` to verify no whitespace/diff issues, and it passed. 
- Verified repository status and inspected diffs locally (no build-time checks failed in this environment). 
- Attempted an Xcode build, but `xcodebuild` is unavailable in the Linux environment so full iOS build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a55ac50f08320a4458f09b217b27a)