### PR TITLE
Align recipe detail and report light mode styling

### DIFF
--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -40,6 +40,7 @@ struct RecipeDetailView: View {
     var body: some View {
         ZStack {
             Color(.systemGroupedBackground)
+                .ignoresSafeArea()
 
             RecipeDetailContent(
                 recipe: recipe,
@@ -64,6 +65,7 @@ struct RecipeDetailView: View {
         }
         .navigationTitle(recipe.name)
         .navigationBarTitleDisplayMode(.large)
+        .toolbar(.visible, for: .navigationBar)
         .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -221,6 +223,7 @@ struct RecipeDetailContent: View {
         .id(accentColorPreference)
         .safeAreaInset(edge: .top, content: { Color.clear.frame(height: 0) })
         .safeAreaInset(edge: .bottom, content: { Color.clear.frame(height: 0) })
+        .background(Color(.systemGroupedBackground))
         .accessibilityElement(children: .contain)
     }
 }
@@ -258,8 +261,8 @@ struct AlternateRecipesSelector: View {
                                 .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
                                 .padding(.vertical, 8)
                                 .background(selectedCraftingOption == index ? Color.userAccentColor : Color.gray.opacity(0.2))
-                                .foregroundColor(.white)
-                                .cornerRadius(10)
+                                .foregroundStyle(selectedCraftingOption == index ? Color.white : Color.primary)
+                                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
                         }
                         .accessibilityLabel("Recipe \(index + 1)")
                         .accessibilityHint("Selects ingredient combination \(index + 1)")

--- a/Craftify/ReportRecipeView.swift
+++ b/Craftify/ReportRecipeView.swift
@@ -140,6 +140,7 @@ struct ReportRecipeView: View {
                         .padding(.vertical, 24)
                         .frame(maxWidth: .infinity)
                     }
+                    .background(Color(.systemGroupedBackground))
                     .id(accentColorPreference)
 
                     if showSubmissionPopup {
@@ -172,6 +173,7 @@ struct ReportRecipeView: View {
                 }
                 .navigationTitle("Report Issue")
                 .navigationBarTitleDisplayMode(.large)
+                .toolbar(.visible, for: .navigationBar)
                 .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
                 .alert("Delete Report", isPresented: $showDeleteConfirmation) {
                     Button("Delete", role: .destructive) {
@@ -397,7 +399,7 @@ struct SubmitReportSection: View {
         }
         .padding(.vertical, 16)
         .padding(.horizontal, 16)
-        .background(Color(.systemBackground))
+        .background(Color(.systemGroupedBackground))
     }
 }
 
@@ -415,12 +417,12 @@ struct ReportTypeToggle: View {
             }) {
                 Text("Missing Recipe")
                     .font(.subheadline)
-                    .foregroundColor(reportType == .missingRecipe ? .white : Color.userAccentColor)
+                    .foregroundStyle(reportType == .missingRecipe ? Color.white : Color.primary)
                     .padding(.vertical, 8)
                     .padding(.horizontal, 12)
                     .frame(maxWidth: .infinity, minHeight: 36)
-                    .background(reportType == .missingRecipe ? Color.userAccentColor : Color(.systemGray6))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .background(reportType == .missingRecipe ? Color.userAccentColor : Color.gray.opacity(0.2))
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             }
             .accessibilityLabel("Report Missing Recipe")
             .accessibilityHint("Select to report a missing recipe")
@@ -434,12 +436,12 @@ struct ReportTypeToggle: View {
             }) {
                 Text("Recipe Error")
                     .font(.subheadline)
-                    .foregroundColor(reportType == .recipeError ? .white : Color.userAccentColor)
+                    .foregroundStyle(reportType == .recipeError ? Color.white : Color.primary)
                     .padding(.vertical, 8)
                     .padding(.horizontal, 12)
                     .frame(maxWidth: .infinity, minHeight: 36)
-                    .background(reportType == .recipeError ? Color.userAccentColor : Color(.systemGray6))
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .background(reportType == .recipeError ? Color.userAccentColor : Color.gray.opacity(0.2))
+                    .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             }
             .accessibilityLabel("Report Recipe Error")
             .accessibilityHint("Select to report an error in a recipe")
@@ -469,8 +471,8 @@ struct CategoryPicker: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
         .frame(maxWidth: .infinity, minHeight: fieldHeight)
-        .background(Color(.systemGray6))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .background(Color(.secondarySystemGroupedBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 12)
                 .stroke(Color.userAccentColor, lineWidth: 2)
@@ -699,8 +701,8 @@ struct MyReportsSection: View {
                         .padding(.vertical, 12)
                         .padding(.horizontal, 16)
                         .frame(maxWidth: .infinity)
-                        .background(Color(.systemGray6))
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                        .background(Color(.secondarySystemGroupedBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
                         .overlay(
                             RoundedRectangle(cornerRadius: 12)
                                 .stroke(
@@ -722,7 +724,7 @@ struct MyReportsSection: View {
         }
         .padding(.vertical, 16)
         .padding(.horizontal, 16)
-        .background(Color(.systemBackground))
+        .background(Color(.systemGroupedBackground))
     }
 }
 


### PR DESCRIPTION
### Motivation
- Bring `RecipeDetailView` and `ReportRecipeView` into parity with the updated light-mode treatment used across `ContentView.swift` and `RecipeSearchView.swift` so screens use grouped backgrounds and readable/inactive text styles. 
- Ensure navigation bars use the same visible material appearance and that scrollable content surfaces extend under safe areas for a consistent visual baseline in light mode.

### Description
- In `RecipeDetailView.swift` extended the grouped background to fill the safe area and added `.toolbar(.visible)` with the same `.toolbarBackground(.ultraThinMaterial)` treatment, and applied `.background(Color(.systemGroupedBackground))` to the content area. 
- Updated alternate-recipe selector buttons to use adaptive text and neutral fills by switching to `.foregroundStyle(...)` and `.clipShape(RoundedRectangle(..., style: .continuous))`. 
- In `ReportRecipeView.swift` applied a grouped background to the scroll area, made the navigation bar visible with the same material treatment, and replaced hard `systemGray*` controls with secondary grouped surfaces for inputs and report cards using `Color(.secondarySystemGroupedBackground)` and continuous corner shapes. 
- Restyled the report-type toggle to use `.foregroundStyle(...)`, a neutral inactive fill `Color.gray.opacity(0.2)`, and continuous rounded corners for visual consistency with the search/recipe UI.

### Testing
- Ran a repository diff/whitespace check and found no formatting or diff-check issues. 
- Verified the working tree reflects the two modified files `RecipeDetailView.swift` and `ReportRecipeView.swift` and that the changes are limited to styling and view modifiers. 
- Full Xcode build and simulator verification were not performed in this environment because Xcode/iOS toolchain is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a75fce9488320a31dc0464433fcd9)