### PR TITLE
Improve report view iPad layout and refresh behavior

### DIFF
--- a/Craftify/ReportRecipeView.swift
+++ b/Craftify/ReportRecipeView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct ReportRecipeView: View {
     @EnvironmentObject private var dataManager: DataManager
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
 
     @State private var viewMode: ViewMode = .submitReport
@@ -76,8 +75,6 @@ struct ReportRecipeView: View {
     }
 
     private var isSubmissionOnCooldown: Bool { remainingSubmissionCooldown > 0 }
-    private var contentWidth: CGFloat? { horizontalSizeClass == .regular ? 720 : nil }
-
     var body: some View {
         ZStack {
             Color(uiColor: .systemGroupedBackground).ignoresSafeArea()
@@ -106,7 +103,7 @@ struct ReportRecipeView: View {
                             isLoadingReports: isLoadingReports,
                             isConnected: dataManager.isConnected,
                             errorMessage: dataManager.errorMessage,
-                            onRefresh: fetchReportStatuses,
+                            onRefresh: { fetchReportStatuses(forceRefresh: true) },
                             onDelete: {
                                 reportToDelete = $0
                                 showDeleteConfirmation = true
@@ -114,9 +111,8 @@ struct ReportRecipeView: View {
                         )
                     }
                 }
-                .frame(maxWidth: contentWidth)
                 .frame(maxWidth: .infinity)
-                .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
+                .padding(.horizontal, 16)
                 .padding(.top, 12)
                 .padding(.bottom, 32)
             }
@@ -282,10 +278,13 @@ struct ReportRecipeView: View {
         submissionState = .idle
     }
 
-    private func fetchReportStatuses() {
+    private func fetchReportStatuses(forceRefresh: Bool = false) {
         guard dataManager.isConnected else {
             isLoadingReports = false
             return
+        }
+        if forceRefresh {
+            dataManager.lastReportStatusFetchTime = nil
         }
         isLoadingReports = true
         dataManager.fetchRecipeReports { result in


### PR DESCRIPTION
### Motivation
- Make `ReportRecipeView` use the full available iPad width and match the layout/padding behaviour used across other views (e.g. `MoreView`).
- Prevent a manual refresh from being treated as a no-op by the `DataManager` cooldown which returns an empty sentinel and replaces existing reports.

### Description
- Remove the fixed regular-width content cap and the `horizontalSizeClass`-based `contentWidth`, allowing the view to expand to the available iPad width and use a consistent horizontal padding of `16` points.
- Replace the `MyReportsSection` refresh action to call `fetchReportStatuses(forceRefresh: true)` so manual refreshes explicitly bypass the cooldown.
- Add a `forceRefresh: Bool = false` parameter to `fetchReportStatuses` and, when `true`, clear `dataManager.lastReportStatusFetchTime` before requesting reports so `DataManager.fetchRecipeReports` does not short-circuit with an empty result.

### Testing
- Ran `git diff --check` to validate the working tree changes and formatting, which completed without errors.
- Attempted to run `xcodebuild` to exercise the app build, but Xcode tooling is not available in this environment so a full build/test could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b43811d2c83208f0a76e6285865d5)