### PR TITLE
Remove legacy favorites import and fully clear saved recipe data

### DIFF
--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -14,7 +14,6 @@ import Network
 @MainActor
 final class DataManager: ObservableObject {
     @Published var recipes: [Recipe] = []
-    @Published var favorites: [Recipe] = []
     @Published private(set) var chests: [RecipeChest] = []
     @Published var recentSearchNames: [String] = []
     @Published var selectedCategory: String? = nil
@@ -101,7 +100,6 @@ final class DataManager: ObservableObject {
         if let localRecipes = loadRecipesFromLocalCache() {
             print("Loaded \(localRecipes.count) recipes from local cache.")
             self.recipes = localRecipes.sorted(by: { $0.name < $1.name })
-            self.syncFavorites()
             self.syncRecentSearches()
         } else {
             print("No local cache found; will fetch from CloudKit on first view load.")
@@ -120,7 +118,6 @@ final class DataManager: ObservableObject {
         Task { @MainActor [weak self] in
             guard let self else { return }
             NSUbiquitousKeyValueStore.default.synchronize()
-            syncFavorites()
             syncChests()
             syncRecentSearches()
         }
@@ -145,39 +142,13 @@ final class DataManager: ObservableObject {
         }
     }
 
-    func isFavorite(recipe: Recipe) -> Bool {
-        return favorites.contains { $0.id == recipe.id }
-    }
-
-    func toggleFavorite(recipe: Recipe) {
-        if let index = favorites.firstIndex(where: { $0.id == recipe.id }) {
-            favorites.remove(at: index)
-        } else {
-            favorites.append(recipe)
-        }
-        saveFavorites()
-    }
-
-    func saveFavorites() {
-        let favoriteIDs = favorites.map { $0.id }
-        NSUbiquitousKeyValueStore.default.set(favoriteIDs, forKey: iCloudFavoritesKey)
-        NSUbiquitousKeyValueStore.default.synchronize()
-    }
-
-    func syncFavorites() {
-        if let savedIDs = NSUbiquitousKeyValueStore.default.array(forKey: iCloudFavoritesKey) as? [Int] {
-            favorites = recipes.filter { savedIDs.contains($0.id) }
-        }
-    }
-
-    func clearFavorites() {
-        favorites = []
+    func clearChestsAndLegacyFavorites() {
         chests = []
         let store = NSUbiquitousKeyValueStore.default
-        store.set(favorites.map { $0.id }, forKey: iCloudFavoritesKey)
+        store.removeObject(forKey: iCloudFavoritesKey)
         store.removeObject(forKey: iCloudChestsKey)
         store.synchronize()
-        print("Cleared saved recipes and chests")
+        print("Cleared chests and legacy favorites")
     }
 
     func createChest(name: String, size: RecipeChest.Size, adding recipe: Recipe? = nil) {
@@ -242,23 +213,6 @@ final class DataManager: ObservableObject {
         if let data = store.data(forKey: iCloudChestsKey),
            let decoded = try? JSONDecoder().decode([RecipeChest].self, from: data) {
             chests = decoded
-        } else if chests.isEmpty,
-                  let favoriteIDs = store.array(forKey: iCloudFavoritesKey) as? [Int],
-                  !favoriteIDs.isEmpty {
-            chests = Self.importedFavoriteChests(from: favoriteIDs)
-            saveChests()
-        }
-    }
-
-    static func importedFavoriteChests(from favoriteIDs: [Int]) -> [RecipeChest] {
-        let chunks = stride(from: 0, to: favoriteIDs.count, by: RecipeChest.Size.large.rawValue).map { start in
-            Array(favoriteIDs[start..<min(start + RecipeChest.Size.large.rawValue, favoriteIDs.count)])
-        }
-
-        return chunks.enumerated().map { index, recipeIDs in
-            let name = chunks.count == 1 ? "Imported Favorites" : "Imported Favorites \(index + 1)"
-            let size: RecipeChest.Size = recipeIDs.count > RecipeChest.Size.small.rawValue ? .large : .small
-            return RecipeChest(name: name, size: size, recipeIDs: recipeIDs)
         }
     }
 
@@ -298,7 +252,6 @@ final class DataManager: ObservableObject {
         // which is not guaranteed to be the main queue. Hop to the main actor
         // before reading iCloud values or updating observable state.
         Task { @MainActor [weak self] in
-            self?.syncFavorites()
             self?.syncChests()
             self?.syncRecentSearches()
         }
@@ -348,7 +301,6 @@ final class DataManager: ObservableObject {
                 let records = try await fetchAllRecords(matching: query, from: database)
                 let fetchedRecipes = records.compactMap(convertRecordToRecipe)
                 recipes = fetchedRecipes.sorted { $0.name < $1.name }
-                syncFavorites()
                 syncRecentSearches()
                 saveRecipesToLocalCache(fetchedRecipes)
                 lastUpdated = Date()
@@ -576,7 +528,7 @@ final class DataManager: ObservableObject {
 
     func clearAllData(completion: @escaping (Bool) -> Void) {
         clearCache { cacheSuccess in
-            self.clearFavorites()
+            self.clearChestsAndLegacyFavorites()
             self.clearRecentSearches()
 
             if cacheSuccess {

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -92,7 +92,6 @@ struct MoreView: View {
                 Text(dataManager.errorMessage ?? "Please try again.")
             }
             .onAppear {
-                dataManager.syncFavorites()
                 dataManager.syncRecentSearches()
             }
             .onDisappear { stopCooldown() }

--- a/Craftify/SupportView.swift
+++ b/Craftify/SupportView.swift
@@ -207,6 +207,7 @@ struct PrivacyPolicyContent: View {
 
                         VStack(alignment: .leading, spacing: 4) {
                             Text("• Chests: Names you enter, chest sizes and ordering, and stored recipe IDs are saved in iCloud to sync your chest room across your devices.")
+                            Text("• Legacy Favorites: If you used Favorites in an earlier version, its recipe IDs may remain in iCloud. Craftify no longer reads or imports them, and \"Clear All Data\" removes them.")
                             Text("• Recent Searches: Recipe names when you search for recipes, stored in iCloud to sync across your devices.")
                             Text("• Recipe Reports (Optional): When you report an issue, you may submit a recipe name, category, and description. These are stored in a private CloudKit database (accessible only to you) for the \"My Reports\" feature, allowing you to view and manage your reports across devices.")
                             Text("• Local Recipe Cache: Recipes are cached on your device for offline access but contain no personal data.")
@@ -248,7 +249,7 @@ struct PrivacyPolicyContent: View {
                             .minimumScaleFactor(0.6)
 
                         VStack(alignment: .leading, spacing: 4) {
-                            Text("• Chests and Recent Searches: Chest names, sizes, ordering, recipe IDs, and recent recipe names are stored in your iCloud account, protected by Apple’s encryption. We cannot access this data.")
+                            Text("• Chests, Legacy Favorites, and Recent Searches: Chest names, sizes, ordering, recipe IDs (including Favorites saved by earlier versions), and recent recipe names are stored in your iCloud account, protected by Apple’s encryption. We cannot access this data.")
                             Text("• Recipe Reports: Stored privately in a CloudKit database (accessible only to you via your iCloud account) for the \"My Reports\" feature.")
                             Text("• Local Recipe Cache: Stored on your device with no personal information.")
                         }
@@ -303,7 +304,7 @@ struct PrivacyPolicyContent: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("• Chests: Swipe a chest or a stored recipe to delete it. Use Edit to rearrange chests.")
                             Text("• Recent Searches: Tap \"Clear All\" in the Search tab to remove all recent searches.")
-                            Text("• Clear All Data: Tap \"Clear All Data\" in this section to delete everything, including Chests, Recent Searches, Recipe Reports, and the local cache.")
+                            Text("• Clear All Data: Tap \"Clear All Data\" in this section to delete everything, including Chests, legacy Favorites, Recent Searches, Recipe Reports, and the local cache.")
                             Text("• Clear Cache: Use \"Clear Cache\" in this section to remove the local cache, keeping iCloud data like Chests.")
                             Text("• Recipe Reports: In the \"My Reports\" section of \"Report Issue\", you can view and delete your reports, which also removes them from CloudKit.")
                         }

--- a/CraftifyTests/CraftifyTests.swift
+++ b/CraftifyTests/CraftifyTests.swift
@@ -50,6 +50,20 @@ struct CraftifyTests {
         // Clean up
         userDefaults.removePersistentDomain(forName: "testCraftify")
     }
+
+    @MainActor
+    @Test func clearingSavedRecipesRemovesChestsAndLegacyFavorites() {
+        let dataManager = DataManager()
+        let store = NSUbiquitousKeyValueStore.default
+        store.set([1, 2, 3], forKey: "favoriteRecipes")
+        dataManager.createChest(name: "Test Chest", size: .small)
+
+        dataManager.clearChestsAndLegacyFavorites()
+
+        #expect(dataManager.chests.isEmpty)
+        #expect(store.object(forKey: "favoriteRecipes") == nil)
+        #expect(store.object(forKey: "recipeChests.v1") == nil)
+    }
 }
 
 extension CraftifyTests {
@@ -64,17 +78,5 @@ extension CraftifyTests {
         let encoded = try JSONEncoder().encode(chest)
         let decoded = try JSONDecoder().decode(RecipeChest.self, from: encoded)
         #expect(decoded == chest)
-    }
-
-    @MainActor
-    @Test func favoriteMigrationPreservesEveryRecipeID() {
-        let favoriteIDs = Array(1...130)
-        let chests = DataManager.importedFavoriteChests(from: favoriteIDs)
-
-        #expect(chests.count == 3)
-        #expect(chests.flatMap(\.recipeIDs) == favoriteIDs)
-        #expect(chests.map(\.recipeIDs.count) == [54, 54, 22])
-        #expect(chests.map(\.size) == [.large, .large, .small])
-        #expect(chests.map(\.name) == ["Imported Favorites 1", "Imported Favorites 2", "Imported Favorites 3"])
     }
 }


### PR DESCRIPTION
### Motivation

- Remove the legacy "Favorites" feature and its automatic migration to chests to simplify the codepath and stop retaining an extra array of favorite IDs in iCloud. 
- Ensure the app’s "Clear All Data" action truly removes both current chest data and any legacy favorites left in iCloud so users can fully purge saved recipe IDs. 
- Update the in-app privacy policy wording to disclose that legacy favorite IDs may remain in iCloud for older installs and that they are removed by the Clear All action. 

### Description

- Deleted the Favorites state and API surface: removed the `@Published var favorites` property and the `isFavorite`, `toggleFavorite`, `saveFavorites`, `syncFavorites`, and the imported-favorites migration logic. 
- Stopped importing legacy favorites during chest sync by changing `syncChests()` to only load explicit chest data and removed the `importedFavoriteChests` helper. 
- Added `clearChestsAndLegacyFavorites()` that clears local `chests` and removes the legacy `favoriteRecipes` iCloud key plus the `recipeChests.v1` key, and wired `clearAllData(...)` to call it. 
- Updated UI and docs: removed calls to `syncFavorites()` from views and updated `SupportView` privacy text to disclose "Legacy Favorites" and that "Clear All Data" removes those legacy IDs. 
- Replaced the old migration unit test with a new test `clearingSavedRecipesRemovesChestsAndLegacyFavorites` that asserts chests and the legacy iCloud key are removed after calling the new clear helper. 

### Testing

- Ran `rg -n "importedFavoriteChests|syncFavorites|clearFavorites|@Published var favorites" Craftify CraftifyTests --glob '*.swift'` to verify obsolete favorites codepaths were removed and found no remaining implementation references. (passed)
- Ran `git diff --check` to validate there are no whitespace/patch issues. (passed)
- Added the unit test `clearingSavedRecipesRemovesChestsAndLegacyFavorites` under `CraftifyTests` to cover the new clearing behavior, but `xcodebuild` was not available in this environment so the test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b64dc68708320a73712f5095fe14a)