### PR TITLE
Enhance chest customization and safety

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -7,6 +7,8 @@ struct ChestsView: View {
     @State private var navigationPath = NavigationPath()
     @State private var editor: ChestEditorContext?
     @State private var showTutorial = false
+    @State private var chestPendingDeletion: RecipeChest?
+    @State private var editMode: EditMode = .inactive
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
@@ -24,16 +26,19 @@ struct ChestsView: View {
                     List {
                         Section {
                             ForEach(dataManager.chests) { chest in
-                                NavigationLink(value: chest.id) {
-                                    ChestRow(chest: chest)
-                                }
-                                .swipeActions(edge: .trailing) {
-                                    Button("Delete", role: .destructive) {
-                                        if let index = dataManager.chests.firstIndex(of: chest) {
-                                            dataManager.deleteChests(at: IndexSet(integer: index))
-                                            HapticFeedback.notification(.success)
-                                        }
+                                Group {
+                                    if editMode.isEditing {
+                                        Button { editor = .edit(chest) } label: { ChestRow(chest: chest) }
+                                            .buttonStyle(.plain)
+                                    } else {
+                                        NavigationLink(value: chest.id) { ChestRow(chest: chest) }
                                     }
+                                }
+                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                    Button("Delete", role: .destructive) {
+                                        chestPendingDeletion = chest
+                                    }
+                                    .tint(.red)
                                     Button("Edit") { editor = .edit(chest) }
                                         .tint(Color.userAccentColor)
                                 }
@@ -42,9 +47,11 @@ struct ChestsView: View {
                                 }
                             }
                             .onMove(perform: dataManager.moveChests)
-                            .onDelete(perform: dataManager.deleteChests)
-                        } header: {
-                            Text("Drag in Edit mode to arrange your chest room")
+                            .onDelete { offsets in
+                                if let index = offsets.first, dataManager.chests.indices.contains(index) {
+                                    chestPendingDeletion = dataManager.chests[index]
+                                }
+                            }
                         }
                     }
                     .listStyle(.insetGrouped)
@@ -68,10 +75,21 @@ struct ChestsView: View {
                 ChestEditorView(context: context)
                     .environmentObject(dataManager)
                     .presentationDetents([.medium])
+                    .presentationSizing(.page)
             }
             .sheet(isPresented: $showTutorial) {
                 ChestsTutorialView()
                     .presentationDetents([.medium, .large])
+                    .presentationSizing(.page)
+            }
+            .alert("Delete \(chestPendingDeletion?.name ?? "chest")?", isPresented: Binding(
+                get: { chestPendingDeletion != nil },
+                set: { if !$0 { chestPendingDeletion = nil } }
+            )) {
+                Button("Cancel", role: .cancel) { chestPendingDeletion = nil }
+                Button("Delete Chest", role: .destructive) { deletePendingChest() }
+            } message: {
+                Text("This permanently removes the chest and its stored recipe list from iCloud.")
             }
             .onAppear {
                 dataManager.syncChests()
@@ -81,7 +99,16 @@ struct ChestsView: View {
                 }
             }
             .animation(reduceMotion ? nil : .snappy, value: dataManager.chests)
+            .environment(\.editMode, $editMode)
         }
+    }
+
+    private func deletePendingChest() {
+        guard let chest = chestPendingDeletion,
+              let index = dataManager.chests.firstIndex(of: chest) else { return }
+        dataManager.deleteChests(at: IndexSet(integer: index))
+        chestPendingDeletion = nil
+        HapticFeedback.notification(.success)
     }
 }
 
@@ -90,7 +117,7 @@ private struct ChestRow: View {
 
     var body: some View {
         HStack(spacing: 16) {
-            Image(systemName: chest.size == .large ? "shippingbox.fill" : "shippingbox")
+            Image(systemName: chest.displaySymbol)
                 .font(.title2)
                 .foregroundStyle(Color.userAccentColor)
                 .frame(width: 44, height: 44)
@@ -174,17 +201,20 @@ struct ChestEditorView: View {
     @Environment(\.dismiss) private var dismiss
     let context: ChestEditorContext
     let recipeToAdd: Recipe?
+    let onSave: (() -> Void)?
     @State private var name: String
     @State private var size: RecipeChest.Size
+    @State private var symbol: String?
     @State private var showShrinkConfirmation = false
 
-    init(context: ChestEditorContext, recipeToAdd: Recipe? = nil) {
+    init(context: ChestEditorContext, recipeToAdd: Recipe? = nil, onSave: (() -> Void)? = nil) {
         self.context = context
         self.recipeToAdd = recipeToAdd
+        self.onSave = onSave
         if case .edit(let chest) = context {
-            _name = State(initialValue: chest.name); _size = State(initialValue: chest.size)
+            _name = State(initialValue: chest.name); _size = State(initialValue: chest.size); _symbol = State(initialValue: chest.symbol)
         } else {
-            _name = State(initialValue: ""); _size = State(initialValue: .small)
+            _name = State(initialValue: ""); _size = State(initialValue: .small); _symbol = State(initialValue: nil)
         }
     }
 
@@ -198,8 +228,13 @@ struct ChestEditorView: View {
                             Text("\(size.title) · \(size.rawValue) slots").tag(size)
                         }
                     }
+                    Picker("Symbol", selection: $symbol) {
+                        Label("Automatic", systemImage: size == .large ? "shippingbox.fill" : "shippingbox").tag(String?.none)
+                        ForEach(Self.symbols, id: \.self) { symbol in
+                            Label(Self.symbolName(symbol), systemImage: symbol).tag(Optional(symbol))
+                        }
+                    }
                 }
-                Section { Text("Java Edition chests use 27 slots for a small chest and 54 for a large chest.") }
             }
             .navigationTitle(context.title)
             .navigationBarTitleDisplayMode(.inline)
@@ -233,17 +268,25 @@ struct ChestEditorView: View {
     private func saveChanges(removingOverflow: Bool = false) {
         switch context {
         case .new:
-            dataManager.createChest(name: name, size: size, adding: recipeToAdd)
+            dataManager.createChest(name: name, size: size, symbol: symbol, adding: recipeToAdd)
         case .edit(let chest):
             guard dataManager.updateChest(
                 chest,
                 name: name,
                 size: size,
+                symbol: symbol,
                 removingOverflow: removingOverflow
             ) else { return }
         }
         HapticFeedback.notification(.success)
         dismiss()
+        onSave?()
+    }
+
+    private static let symbols = ["archivebox.fill", "cube.fill", "shippingbox.and.arrow.backward.fill", "backpack.fill", "square.grid.3x3.fill", "building.columns.fill", "mountain.2.fill", "flame.fill", "diamond.fill", "hammer.fill"]
+
+    private static func symbolName(_ symbol: String) -> String {
+        ["archivebox.fill": "Storage", "cube.fill": "Block", "shippingbox.and.arrow.backward.fill": "Delivery", "backpack.fill": "Inventory", "square.grid.3x3.fill": "Crafting Grid", "building.columns.fill": "Stronghold", "mountain.2.fill": "Mountains", "flame.fill": "Nether", "diamond.fill": "Diamond", "hammer.fill": "Tools"][symbol] ?? symbol
     }
 }
 
@@ -261,7 +304,8 @@ struct ChestsTutorialView: View {
                         .font(.largeTitle.bold()).foregroundStyle(Color.userAccentColor)
                     TutorialStep(icon: "plus.circle.fill", title: "Collect recipes", text: "Tap + on a recipe and choose a chest, or create one without leaving the recipe.")
                     TutorialStep(icon: "square.grid.3x3.fill", title: "Minecraft-sized storage", text: "Small chests hold 27 recipes. Large chests hold 54, just like Java Edition.")
-                    TutorialStep(icon: "arrow.up.arrow.down", title: "Make it yours", text: "Use Edit to rearrange chests. Swipe a chest to rename or delete it.")
+                    TutorialStep(icon: "paintpalette.fill", title: "Make it yours", text: "Give every chest a name and a Minecraft-inspired symbol that fits what you store.")
+                    TutorialStep(icon: "arrow.up.arrow.down", title: "Arrange safely", text: "Use Edit to drag chests into order, or tap one to change its name, size, or symbol. Swipe for Edit and a confirmed Delete.")
                     Text("Your chest room syncs through iCloud, so its order, names, and recipes follow you across devices.")
                         .font(.callout).foregroundStyle(.secondary)
                 }.padding(24)

--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -165,10 +165,10 @@ final class DataManager: ObservableObject {
         print("Cleared chests and legacy favorites")
     }
 
-    func createChest(name: String, size: RecipeChest.Size, adding recipe: Recipe? = nil) {
+    func createChest(name: String, size: RecipeChest.Size, symbol: String? = nil, adding recipe: Recipe? = nil) {
         let cleanedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         let recipeIDs = recipe.map { [$0.id] } ?? []
-        chests.append(RecipeChest(name: cleanedName.isEmpty ? "New Chest" : cleanedName, size: size, recipeIDs: recipeIDs))
+        chests.append(RecipeChest(name: cleanedName.isEmpty ? "New Chest" : cleanedName, size: size, symbol: symbol, recipeIDs: recipeIDs))
         saveChests()
     }
 
@@ -177,6 +177,7 @@ final class DataManager: ObservableObject {
         _ chest: RecipeChest,
         name: String,
         size: RecipeChest.Size,
+        symbol: String?,
         removingOverflow: Bool = false
     ) -> Bool {
         guard let index = chests.firstIndex(where: { $0.id == chest.id }) else { return false }
@@ -185,6 +186,7 @@ final class DataManager: ObservableObject {
         let cleanedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         chests[index].name = cleanedName.isEmpty ? chest.name : cleanedName
         chests[index].size = size
+        chests[index].symbol = symbol
         if overflowCount > 0 {
             chests[index].recipeIDs.removeLast(overflowCount)
         }

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -276,7 +276,7 @@ private struct OnboardingPageView: View {
                 }
                 .frame(maxWidth: 520)
 
-                if page.title == "Keep favorites close" {
+                if page.title == "Choose your look" {
                     VStack(alignment: .leading, spacing: 12) {
                         HStack(spacing: 14) {
                             Image(systemName: "paintpalette.fill")
@@ -426,13 +426,23 @@ private struct OnboardingPage {
             ]
         ),
         OnboardingPage(
-            eyebrow: "Make it yours",
-            title: "Keep favorites close",
-            detail: "Save the recipes you use most and personalize Craftify with your favorite accent.",
-            symbol: "heart.fill",
+            eyebrow: "Plan your projects",
+            title: "Build your chest room",
+            detail: "Collect recipes in Minecraft-sized chests so every build has an organized plan.",
+            symbol: "shippingbox.fill",
             highlights: [
-                Highlight(symbol: "heart.circle", text: "Build a personal shortlist for every project"),
-                Highlight(symbol: "icloud", text: "Favorites sync across all your devices")
+                Highlight(symbol: "square.grid.3x3.fill", text: "Choose 27-slot or 54-slot chests for each project"),
+                Highlight(symbol: "paintbrush.pointed.fill", text: "Personalize every chest with a name and symbol")
+            ]
+        ),
+        OnboardingPage(
+            eyebrow: "Your Craftify",
+            title: "Choose your look",
+            detail: "Pick an accent that feels like yours. You can change it whenever you like.",
+            symbol: "paintpalette.fill",
+            highlights: [
+                Highlight(symbol: "circle.hexagongrid.fill", text: "Preview your accent across the whole experience"),
+                Highlight(symbol: "accessibility", text: "Designed to stay clear in light and dark appearances")
             ]
         )
     ]

--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -176,7 +176,7 @@ private struct AddRecipeToChestView: View {
                                 }
                             } label: {
                                 HStack {
-                                    Label(chest.name, systemImage: "shippingbox")
+                                    Label(chest.name, systemImage: chest.displaySymbol)
                                     Spacer()
                                     Text("\(chest.recipeIDs.count)/\(chest.size.rawValue)")
                                         .foregroundStyle(.secondary)
@@ -192,9 +192,13 @@ private struct AddRecipeToChestView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar { ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } } }
             .sheet(isPresented: $creatingChest) {
-                ChestEditorView(context: .new, recipeToAdd: recipe)
+                ChestEditorView(context: .new, recipeToAdd: recipe) {
+                    creatingChest = false
+                    dismiss()
+                }
                     .environmentObject(dataManager)
                     .presentationDetents([.medium])
+                    .presentationSizing(.page)
             }
             .alert("Couldn’t Add Recipe", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
                 Button("OK", role: .cancel) { message = nil }

--- a/Craftify/Recipes.swift
+++ b/Craftify/Recipes.swift
@@ -92,14 +92,18 @@ struct RecipeChest: Codable, Identifiable, Equatable, Hashable {
     let id: UUID
     var name: String
     var size: Size
+    var symbol: String?
     var recipeIDs: [Int]
 
-    init(id: UUID = UUID(), name: String, size: Size, recipeIDs: [Int] = []) {
+    init(id: UUID = UUID(), name: String, size: Size, symbol: String? = nil, recipeIDs: [Int] = []) {
         self.id = id
         self.name = name
         self.size = size
+        self.symbol = symbol
         self.recipeIDs = Array(recipeIDs.prefix(size.rawValue))
     }
+
+    var displaySymbol: String { symbol ?? (size == .large ? "shippingbox.fill" : "shippingbox") }
 }
 
 struct RecipeReport: Identifiable, Codable {


### PR DESCRIPTION
### Motivation

- Make chest management safer and clearer by preventing accidental destructive swipes and adding an explicit confirmation step. 
- Improve cross-device presentation and personalization by exposing chest symbols, surfacing an edit flow that works well on iPad, and updating tutorial/onboarding to teach the new features.

### Description

- Prevent full-swipe deletion and require an explicit confirmation alert for deletes, while ensuring the destructive action visually appears red (`swipeActions(allowsFullSwipe: false)`, pending-delete + `.alert`, `.tint(.red)`).
- Add persistent SF-Symbol customization to `RecipeChest` (`symbol` + `displaySymbol`) and expose a symbol picker in `ChestEditorView` with a curated set of Minecraft-inspired symbols. 
- Allow tapping a chest row while in Edit mode to open the chest editor, and show the chosen symbol across the UI (chest rows and the chest picker in `RecipeDetailView`).
- Use page-style detented presentation on larger devices for chest sheets (`.presentationSizing(.page)`), and automatically dismiss the recipe chest creation flow after saving via an `onSave` callback.
- Remove redundant inline explanatory text from the main chest list and move capacity/customization/safe-arranging guidance into the chest tutorial, and refresh onboarding pages to introduce the chest-room flow and move appearance selection to its own page.

### Testing

- `git diff --check` was run and passed.
- Verified usages of the updated API with `rg -n "updateChest("`, and inspected affected files with `git diff --stat` to confirm changes to `ChestsView.swift`, `DataManager.swift`, `OnboardingView.swift`, `RecipeDetailView.swift`, and `Recipes.swift`.
- Changes were staged and committed locally (`git status --short` showed a clean working tree after commit).
- Attempted `xcodebuild` to build the app but it could not be run in this environment (`/bin/bash: line 1: xcodebuild: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bc63f288c8320b1ce8260fc731cec)