### PR TITLE
Refresh onboarding, empty-library guidance, and chest appearance syncing

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ChestsView: View {
     @EnvironmentObject private var dataManager: DataManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
     @AppStorage("hasSeenChestsTutorial") private var hasSeenTutorial = false
     @State private var navigationPath = NavigationPath()
     @State private var editor: ChestEditorContext?
@@ -58,6 +59,8 @@ struct ChestsView: View {
                 }
             }
             .background(Color(.systemGroupedBackground))
+            .id(accentColorPreference)
+            .tint(Color.userAccentColor)
             .navigationTitle("Chests")
             .navigationDestination(for: UUID.self) { id in
                 if let chest = dataManager.chests.first(where: { $0.id == id }) {
@@ -199,6 +202,7 @@ enum ChestEditorContext: Identifiable {
 struct ChestEditorView: View {
     @EnvironmentObject private var dataManager: DataManager
     @Environment(\.dismiss) private var dismiss
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
     let context: ChestEditorContext
     let recipeToAdd: Recipe?
     let onSave: (() -> Void)?
@@ -256,6 +260,8 @@ struct ChestEditorView: View {
             } message: {
                 Text("A small chest holds 27 recipes. Shrinking will permanently remove the last \(overflowCount) recipes from this chest and sync the change to iCloud.")
             }
+            .id(accentColorPreference)
+            .tint(Color.userAccentColor)
         }
     }
 

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -287,6 +287,7 @@ struct CategoryFilterBar: View {
 }
 
 struct RecipeListView: View {
+    @EnvironmentObject private var dataManager: DataManager
     @Binding var recommendedRecipes: [Recipe]
     @Binding var isCraftifyPicksExpanded: Bool
     let filteredRecipes: [String: [Recipe]]
@@ -299,8 +300,12 @@ struct RecipeListView: View {
     @ScaledMetric(relativeTo: .body) private var paddingVertical: CGFloat = 8
 
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+        Group {
+            if dataManager.recipes.isEmpty {
+                EmptyFavoritesView()
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
                 if !recommendedRecipes.isEmpty {
                     Section {
                         if isCraftifyPicksExpanded {
@@ -372,11 +377,12 @@ struct RecipeListView: View {
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .background(Color(.systemGroupedBackground))
                     }
+                    }
                 }
+                .scrollContentBackground(.hidden)
             }
         }
         .id(accentColorPreference)
-        .scrollContentBackground(.hidden)
         .background(Color(.systemGroupedBackground))
         .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 0) }
         .dynamicTypeSize(.xSmall ... .accessibility5)

--- a/Craftify/EmptyFavoritesView.swift
+++ b/Craftify/EmptyFavoritesView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+/// The recipe library's recovery state after its local data has been cleared.
+struct EmptyFavoritesView: View {
+    @ScaledMetric(relativeTo: .body) private var iconSize: CGFloat = 36
+    @ScaledMetric(relativeTo: .body) private var spacing: CGFloat = 12
+    @ScaledMetric(relativeTo: .body) private var padding: CGFloat = 16
+
+    var body: some View {
+        VStack(spacing: spacing) {
+            Image(systemName: "arrow.triangle.2.circlepath.icloud")
+                .font(.system(size: iconSize))
+                .foregroundStyle(Color.userAccentColor)
+
+            Text("No recipes on this device")
+                .font(.title)
+                .bold()
+                .multilineTextAlignment(.center)
+
+            Text("Head to More and choose Sync Recipes to fetch the recipe library again.")
+                .font(.headline)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, padding)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(padding)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No recipes on this device. Head to More and choose Sync Recipes to fetch the recipe library again.")
+        .dynamicTypeSize(.xSmall ... .accessibility5)
+    }
+}

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -418,11 +418,11 @@ private struct OnboardingPage {
         OnboardingPage(
             eyebrow: "Find anything",
             title: "Search in an instant",
-            detail: "Jump straight to an item or explore recipes by category.",
+            detail: "Find any recipe by its name or by an ingredient you already have.",
             symbol: "magnifyingglass",
             highlights: [
-                Highlight(symbol: "line.3.horizontal.decrease.circle", text: "Filter categories to narrow the recipe list"),
-                Highlight(symbol: "arrow.triangle.branch", text: "Follow ingredients and nested recipes step by step")
+                Highlight(symbol: "line.3.horizontal.decrease.circle", text: "Choose whether to search names, ingredients, or both"),
+                Highlight(symbol: "clock.arrow.circlepath", text: "Quickly return to recipes from your recent searches")
             ]
         ),
         OnboardingPage(
@@ -432,7 +432,8 @@ private struct OnboardingPage {
             symbol: "shippingbox.fill",
             highlights: [
                 Highlight(symbol: "square.grid.3x3.fill", text: "Choose 27-slot or 54-slot chests for each project"),
-                Highlight(symbol: "paintbrush.pointed.fill", text: "Personalize every chest with a name and symbol")
+                Highlight(symbol: "paintbrush.pointed.fill", text: "Personalize every chest with a name and symbol"),
+                Highlight(symbol: "icloud.fill", text: "Sync your chest room through iCloud across your devices")
             ]
         ),
         OnboardingPage(


### PR DESCRIPTION
### Motivation

- Surface that chests sync via iCloud in onboarding so the chest-room feature is easier to market. 
- Align the onboarding “Search in an instant” messaging with the recent `RecipeSearchView.swift` changes that let users search names, ingredients, or both and show recent searches. 
- Reuse the existing empty-favorites UI to provide a clear recovery path after users clear local data, directing them to `More → Sync Recipes`. 
- Ensure chest symbols and editor controls reflect the selected accent color so chest UI updates immediately with appearance changes.

### Description

- Updated the onboarding pages in `OnboardingView.swift` to change the Search page text and highlights and to add an iCloud-sync highlight to the chest page. 
- Added `EmptyFavoritesView.swift` (recycled from prior favorites UI) which instructs users to go to `More` → `Sync Recipes` when the local recipe library is empty. 
- Plumbed the empty-library view into the main recipe list by showing `EmptyFavoritesView` from `ContentView.swift`/`RecipeListView` when the local recipe list is empty. 
- Made `ChestsView.swift` and `ChestEditorView` observe the `accentColorPreference` (`@AppStorage(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bc8bc8ec88320bc745b4e623fd694)