### PR TITLE
Fix recipe list compilation and resilient chest deletion

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -108,7 +108,7 @@ struct ChestsView: View {
 
     private func deletePendingChest() {
         guard let chest = chestPendingDeletion,
-              let index = dataManager.chests.firstIndex(of: chest) else { return }
+              let index = dataManager.chests.firstIndex(where: { $0.id == chest.id }) else { return }
         dataManager.deleteChests(at: IndexSet(integer: index))
         chestPendingDeletion = nil
         HapticFeedback.notification(.success)

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -382,6 +382,7 @@ struct RecipeListView: View {
                 .scrollContentBackground(.hidden)
             }
         }
+        }
         .id(accentColorPreference)
         .background(Color(.systemGroupedBackground))
         .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 0) }


### PR DESCRIPTION
### Motivation
- Resolve compilation errors caused by a malformed view-builder in `RecipeListView` that led to an unexpected `.id` usage and a missing struct brace.  
- Make chest deletion resilient to iCloud-driven field updates by identifying the pending chest by its stable UUID instead of full-value equality.

### Description
- Close the outer `Group`/view-builder in `RecipeListView` (in `ContentView.swift`) so view modifiers like `.id(accentColorPreference)` apply to the correct view scope, fixing the malformed structure.  
- Update `deletePendingChest()` in `ChestsView.swift` to locate the pending chest with `firstIndex(where: { $0.id == chest.id })` so synchronized changes to other fields do not prevent deletion.  
- Minor whitespace/structuring adjustments to restore a well-formed SwiftUI view hierarchy.

### Testing
- Ran `swiftc -frontend -parse Craftify/ContentView.swift Craftify/ChestsView.swift`, which completed without parse errors.  
- Ran `git diff --check`, which produced no style or whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6bcb463c3c83209185da423ead7f38)