### PR TITLE
Fix ChestsView type-checking by extracting ChestListRow and surface accent color labels in onboarding

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -31,25 +31,12 @@ struct ChestsView: View {
                     List {
                         Section {
                             ForEach(dataManager.chests) { chest in
-                                Group {
-                                    if editMode.isEditing {
-                                        Button { editor = .edit(chest) } label: { ChestRow(chest: chest) }
-                                            .buttonStyle(.plain)
-                                    } else {
-                                        NavigationLink(value: chest.id) { ChestRow(chest: chest) }
-                                    }
-                                }
-                                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                                    Button("Delete", role: .destructive) {
-                                        chestPendingDeletion = chest
-                                    }
-                                    .tint(.red)
-                                    Button("Edit") { editor = .edit(chest) }
-                                        .tint(Color.userAccentColor)
-                                }
-                                .contextMenu {
-                                    Button("Edit Chest", systemImage: "pencil") { editor = .edit(chest) }
-                                }
+                                ChestListRow(
+                                    chest: chest,
+                                    isEditing: editMode.isEditing,
+                                    onEdit: { editor = .edit(chest) },
+                                    onDelete: { chestPendingDeletion = chest }
+                                )
                             }
                             .onMove(perform: dataManager.moveChests)
                             .onDelete { offsets in
@@ -131,6 +118,40 @@ struct ChestsView: View {
         dataManager.deleteChests(at: IndexSet(integer: index))
         chestPendingDeletion = nil
         HapticFeedback.notification(.success)
+    }
+}
+
+private struct ChestListRow: View {
+    let chest: RecipeChest
+    let isEditing: Bool
+    let onEdit: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        rowContent
+            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                Button("Delete", role: .destructive, action: onDelete)
+                    .tint(.red)
+                Button("Edit", action: onEdit)
+                    .tint(Color.userAccentColor)
+            }
+            .contextMenu {
+                Button("Edit Chest", systemImage: "pencil", action: onEdit)
+            }
+    }
+
+    @ViewBuilder
+    private var rowContent: some View {
+        if isEditing {
+            Button(action: onEdit) {
+                ChestRow(chest: chest)
+            }
+            .buttonStyle(.plain)
+        } else {
+            NavigationLink(value: chest.id) {
+                ChestRow(chest: chest)
+            }
+        }
     }
 }
 

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -303,7 +303,7 @@ private struct OnboardingPageView: View {
     }
 
     private var accentColorPicker: some View {
-        let columns = [GridItem(.adaptive(minimum: 44), spacing: 12, alignment: .leading)]
+        let columns = [GridItem(.adaptive(minimum: 72), spacing: 12, alignment: .leading)]
 
         return LazyVGrid(columns: columns, spacing: 12) {
             ForEach(AppAppearanceView.accentColors) { option in
@@ -319,16 +319,24 @@ private struct OnboardingPageView: View {
         return Button {
             selectAccentColor(option.id)
         } label: {
-            Circle()
-                .fill(option.color)
-                .frame(width: 34, height: 34)
-                .overlay {
-                    if isSelected {
-                        Image(systemName: "checkmark")
-                            .font(.caption.bold())
-                            .foregroundStyle(.white)
+            VStack(spacing: 6) {
+                Circle()
+                    .fill(option.color)
+                    .frame(width: 34, height: 34)
+                    .overlay {
+                        if isSelected {
+                            Image(systemName: "checkmark")
+                                .font(.caption.bold())
+                                .foregroundStyle(.white)
+                        }
                     }
-                }
+                Text(option.name)
+                    .font(.caption2)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+            }
+            .frame(maxWidth: .infinity)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(option.name)


### PR DESCRIPTION
### Motivation

- The Swift compiler hit a long/complex expression in `ChestsView.swift` which caused a type-check timeout; the goal is to simplify the view expression so Xcode can compile reliably. 
- Users should be able to preview the newly added accent colors during onboarding, so the accent palette there should render each swatch with a visible label. 

### Description

- Extracted the per-row logic into a dedicated `ChestListRow` SwiftUI view to reduce the large generic expression inside `ForEach` and make the compiler type-check the layout faster. 
- `ChestListRow` preserves the previous behaviors including navigation, edit-mode rendering, swipe actions, and context-menu editing by accepting `isEditing`, `onEdit`, and `onDelete` callbacks. 
- Replaced the former inlined row code in `ChestsView` with `ChestListRow` instances and kept edit, delete, movement, alert, and tutorial behavior intact. 
- Updated the onboarding accent-color picker to use a larger adaptive grid and include a text label under each swatch so every accent (including the newly added ones) is clearly previewable and selectable. 

### Testing

- Ran `swiftc -frontend -parse Craftify/ChestsView.swift Craftify/OnboardingView.swift` and it completed successfully. 
- Ran `git diff --check` and repository checks passed. 
- Committed the changes (`Fix chest view type checking and show accent palette`). 
- Attempted `xcodebuild -project Craftify.xcodeproj -scheme Craftify -sdk iphonesimulator -configuration Debug build` but Xcode is not available in this Linux environment so an app build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6be8a5441483209d27189215f17aa5)