### PR TITLE
Fix ChestsView edit animation type-check timeout

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -67,12 +67,7 @@ struct ChestsView: View {
                         showTutorial = true
                     }
                     if !dataManager.chests.isEmpty {
-                        Button(editMode.isEditing ? "Done" : "Edit") {
-                            HapticFeedback.impact()
-                            withAnimation(reduceMotion ? nil : .default) {
-                                editMode = editMode.isEditing ? .inactive : .active
-                            }
-                        }
+                        Button(editMode.isEditing ? "Done" : "Edit", action: toggleEditMode)
                     }
                     Button("New Chest", systemImage: "plus") {
                         HapticFeedback.impact()
@@ -118,6 +113,15 @@ struct ChestsView: View {
         dataManager.deleteChests(at: IndexSet(integer: index))
         chestPendingDeletion = nil
         HapticFeedback.notification(.success)
+    }
+
+    private func toggleEditMode() {
+        HapticFeedback.impact()
+        let animation: Animation? = reduceMotion ? nil : Animation.default
+        let nextEditMode: EditMode = editMode.isEditing ? .inactive : .active
+        withAnimation(animation) {
+            editMode = nextEditMode
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- The Swift compiler timed out type-checking a complex inline toolbar closure when toggling the chest list edit mode, so the edit-mode transition was extracted to simplify type inference and avoid the timeout.

### Description
- Replace the inline toolbar `Button` closure with `Button(..., action: toggleEditMode)` to remove heavy type inference from the result builder.
- Add a new `private func toggleEditMode()` that computes `let animation: Animation? = reduceMotion ? nil : Animation.default` and `let nextEditMode: EditMode = editMode.isEditing ? .inactive : .active` before calling `withAnimation(animation) { editMode = nextEditMode }`.
- Preserve existing `HapticFeedback` calls and honor the `accessibilityReduceMotion` setting while making the types explicit for the compiler.

### Testing
- Ran `git diff --check` to validate there are no obvious whitespace or diff errors, which succeeded.
- Attempted the iOS build with `xcodebuild -project Craftify.xcodeproj -scheme Craftify -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO build`, but Xcode was unavailable in the Linux environment so the iOS build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6be9f573808320ac394eac37dc4db4)