### PR TITLE
Add 'Forest' accent color and improve responsive accessibility in chest and onboarding views

### DIFF
--- a/Craftify/AppAppearanceView.swift
+++ b/Craftify/AppAppearanceView.swift
@@ -52,8 +52,7 @@ struct AppAppearanceView: View {
         .init(id: "pink", name: "Pink", color: .pink),
         .init(id: "yellow", name: "Yellow", color: .yellow),
         .init(id: "indigo", name: "Indigo", color: .indigo),
-        .init(id: "mint", name: "Mint", color: .mint),
-        .init(id: "cyan", name: "Cyan", color: .cyan),
+        .init(id: "forest", name: "Forest", color: Color(hex: "287A3D")),
         .init(id: "brown", name: "Brown", color: .brown),
         .init(id: "slate", name: "Slate", color: Color(hex: "607D8B"))
     ]

--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -214,6 +214,8 @@ private struct ChestRow: View {
 struct ChestDetailView: View {
     @EnvironmentObject private var dataManager: DataManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
     let chestID: UUID
     @Binding var navigationPath: NavigationPath
@@ -221,7 +223,13 @@ struct ChestDetailView: View {
     @State private var chestName = ""
 
     private let cardSpacing: CGFloat = 14
-    private let minimumCardWidth: CGFloat = 160
+
+    private var gridColumns: [GridItem] {
+        let columnCount = dynamicTypeSize.isAccessibilitySize
+            ? 1
+            : (horizontalSizeClass == .regular ? 3 : 2)
+        return Array(repeating: GridItem(.flexible(), spacing: cardSpacing), count: columnCount)
+    }
 
     private var chest: RecipeChest? { dataManager.chests.first { $0.id == chestID } }
 
@@ -238,7 +246,7 @@ struct ChestDetailView: View {
                             name: $chestName
                         )
                         LazyVGrid(
-                            columns: [GridItem(.adaptive(minimum: minimumCardWidth), spacing: cardSpacing)],
+                            columns: gridColumns,
                             spacing: cardSpacing
                         ) {
                             ForEach(Array(storedRecipes.enumerated()), id: \.element.id) { slot, recipe in
@@ -266,7 +274,11 @@ struct ChestDetailView: View {
                     Button(editMode.isEditing ? "Done" : "Edit", action: toggleEditMode)
                 }
                 .environment(\.editMode, $editMode)
-                .onAppear { chestName = chest.name }
+                .onAppear {
+                    if !editMode.isEditing {
+                        chestName = chest.name
+                    }
+                }
                 .onChange(of: chest.name) { _, newName in
                     if !editMode.isEditing { chestName = newName }
                 }
@@ -343,6 +355,7 @@ private struct ChestDetailHeader: View {
 }
 
 private struct ChestRecipeCard: View {
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     let recipe: Recipe
     let slot: Int
     var body: some View {
@@ -356,11 +369,13 @@ private struct ChestRecipeCard: View {
                 .background(Color.black.opacity(0.88))
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 5) {
-                Text(recipe.name).font(.headline).foregroundStyle(.primary).lineLimit(2)
+                Text(recipe.name).font(.headline).foregroundStyle(.primary)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
                 Text(recipe.category).font(.caption.weight(.semibold))
-                    .foregroundStyle(Color.userAccentColor).lineLimit(1)
+                    .foregroundStyle(Color.userAccentColor)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
             }
-            .frame(maxWidth: .infinity, height: 68, alignment: .topLeading)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
             .padding(12)
             .background(Color(.secondarySystemGroupedBackground))
         }

--- a/Craftify/ColorExtension.swift
+++ b/Craftify/ColorExtension.swift
@@ -39,10 +39,8 @@ extension Color {
             return .yellow
         case "indigo":
             return .indigo
-        case "mint":
-            return .mint
-        case "cyan":
-            return .cyan
+        case "forest":
+            return Color(hex: "287A3D")
         case "brown":
             return .brown
         case "slate":

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -219,6 +219,7 @@ private struct OnboardingPageView: View {
     let page: OnboardingPage
     let isCurrent: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
 
     var body: some View {
@@ -303,7 +304,9 @@ private struct OnboardingPageView: View {
     }
 
     private var accentColorPicker: some View {
-        let columns = [GridItem(.adaptive(minimum: 72), spacing: 12, alignment: .leading)]
+        let columns = dynamicTypeSize.isAccessibilitySize
+            ? [GridItem(.flexible(), alignment: .leading)]
+            : [GridItem(.adaptive(minimum: 72), spacing: 12, alignment: .leading)]
 
         return LazyVGrid(columns: columns, spacing: 12) {
             ForEach(AppAppearanceView.accentColors) { option in


### PR DESCRIPTION
### Motivation

- Introduce a new "Forest" accent option and replace deprecated mint/cyan choices to better match branding and color palettes.
- Improve layout and accessibility for chests and onboarding so UI adapts correctly to large Dynamic Type and different size classes.

### Description

- Replaced `mint`/`cyan` accent options with a `forest` color using hex `#287A3D` and exposed it via `AppAppearanceView.accentColors` and `Color.userAccentColor` mapping.
- Updated `ChestDetailView` to compute `gridColumns` using `dynamicTypeSize` and `horizontalSizeClass` instead of an adaptive minimum width and adjusted `onAppear` to avoid overwriting in-edit names while editing. 
- Modified `ChestRecipeCard` to respect `dynamicTypeSize` by removing fixed line limits when accessibility sizes are active and relaxed fixed height constraints for better readability.
- Updated onboarding accent picker in `OnboardingPageView` to use a single flexible column when `dynamicTypeSize.isAccessibilitySize` to improve button layout for large text sizes.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ce22853d8832093daa536b2e26f4a)