### PR TITLE
Fix chest recipe card image background

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -366,7 +366,7 @@ private struct ChestRecipeCard: View {
                 .frame(maxWidth: .infinity)
                 .frame(height: 88)
                 .padding(12)
-                .background(Color.black.opacity(0.88))
+                .background(Color(.systemBackground))
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 5) {
                 Text(recipe.name).font(.headline).foregroundStyle(.primary)


### PR DESCRIPTION
### Motivation
- The chest slot recipe cards used a hard-coded near-black background which looked wrong against the surrounding grouped/system backgrounds and did not adapt to light/dark appearances.

### Description
- Replace the image area background in `ChestRecipeCard` from `Color.black.opacity(0.88)` to the adaptive `Color(.systemBackground)` in `Craftify/ChestsView.swift` so the slot cards match the main views.

### Testing
- Ran `git diff --check` which passed, and an attempt to run `xcodebuild` could not be completed in this environment because `xcodebuild` is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6ce5f028188320842314993cdb006a)