### PR TITLE
Extend the chest detail hero through the navigation area

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -249,54 +249,57 @@ struct ChestDetailView: View {
                             isEditing: editMode.isEditing,
                             name: $chestName
                         )
-                        if storedRecipes.isEmpty {
-                            ContentUnavailableView {
-                                Label("No Stored Recipes", systemImage: "square.grid.3x3")
-                            } description: {
-                                Text("Open a recipe and use the add button to store it in this chest.")
-                            }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 36)
-                        } else {
-                            VStack(alignment: .leading, spacing: 12) {
-                                Text("Stored Recipes")
-                                    .font(.title2.bold())
-                                    .accessibilityAddTraits(.isHeader)
+                        Group {
+                            if storedRecipes.isEmpty {
+                                ContentUnavailableView {
+                                    Label("No Stored Recipes", systemImage: "square.grid.3x3")
+                                } description: {
+                                    Text("Open a recipe and use the add button to store it in this chest.")
+                                }
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 36)
+                            } else {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    Text("Stored Recipes")
+                                        .font(.title2.bold())
+                                        .accessibilityAddTraits(.isHeader)
 
-                                LazyVGrid(columns: gridColumns, spacing: cardSpacing) {
-                                    ForEach(Array(storedRecipes.enumerated()), id: \.element.id) { slot, recipe in
-                                        ZStack(alignment: .topTrailing) {
-                                            NavigationLink(value: recipe) {
-                                                ChestRecipeCard(recipe: recipe, slot: slot + 1)
-                                            }
-                                            .buttonStyle(.plain)
-
-                                            if editMode.isEditing {
-                                                Button("Remove \(recipe.name)", systemImage: "minus.circle.fill") {
-                                                    dataManager.removeRecipes(withIDs: [recipe.id], from: chestID)
-                                                    HapticFeedback.impact()
+                                    LazyVGrid(columns: gridColumns, spacing: cardSpacing) {
+                                        ForEach(Array(storedRecipes.enumerated()), id: \.element.id) { slot, recipe in
+                                            ZStack(alignment: .topTrailing) {
+                                                NavigationLink(value: recipe) {
+                                                    ChestRecipeCard(recipe: recipe, slot: slot + 1)
                                                 }
-                                                .labelStyle(.iconOnly)
-                                                .font(.title2)
-                                                .foregroundStyle(.white, .red)
-                                                .frame(minWidth: 44, minHeight: 44)
-                                                .contentShape(Rectangle())
-                                                .accessibilityHint("Removes this recipe from \(chest.name)")
-                                                .transition(reduceMotion ? .opacity : .scale.combined(with: .opacity))
+                                                .buttonStyle(.plain)
+
+                                                if editMode.isEditing {
+                                                    Button("Remove \(recipe.name)", systemImage: "minus.circle.fill") {
+                                                        dataManager.removeRecipes(withIDs: [recipe.id], from: chestID)
+                                                        HapticFeedback.impact()
+                                                    }
+                                                    .labelStyle(.iconOnly)
+                                                    .font(.title2)
+                                                    .foregroundStyle(.white, .red)
+                                                    .frame(minWidth: 44, minHeight: 44)
+                                                    .contentShape(Rectangle())
+                                                    .accessibilityHint("Removes this recipe from \(chest.name)")
+                                                    .transition(reduceMotion ? .opacity : .scale.combined(with: .opacity))
+                                                }
                                             }
                                         }
                                     }
                                 }
                             }
                         }
+                        .frame(maxWidth: 1200)
+                        .padding(.horizontal, pagePadding)
+                        .padding(.bottom, pagePadding)
+                        .frame(maxWidth: .infinity)
                     }
-                    .frame(maxWidth: 1200)
-                    .padding(pagePadding)
-                    .frame(maxWidth: .infinity)
                 }
                 .background(Color(.systemGroupedBackground))
                 .id(accentColorPreference).tint(Color.userAccentColor)
-                .navigationTitle(chest.name).navigationBarTitleDisplayMode(.inline)
+                .toolbarBackground(.hidden, for: .navigationBar)
                 .toolbar {
                     Button(editMode.isEditing ? "Done" : "Edit", action: toggleEditMode)
                 }
@@ -344,6 +347,7 @@ struct ChestDetailView: View {
 }
 
 private struct ChestDetailHeader: View {
+    @Environment(\.colorScheme) private var colorScheme
     let chest: RecipeChest
     let usedSlots: Int
     let isEditing: Bool
@@ -361,22 +365,23 @@ private struct ChestDetailHeader: View {
                 details(centered: true)
             }
         }
-        .padding(20)
+        .frame(maxWidth: 1200)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 24)
         .frame(maxWidth: .infinity)
         .background {
             ZStack {
                 Color(.secondarySystemGroupedBackground)
                 LinearGradient(
-                    colors: [Color.userAccentColor.opacity(0.20), Color.userAccentColor.opacity(0.03)],
+                    colors: [
+                        Color.userAccentColor.opacity(colorScheme == .dark ? 0.34 : 0.20),
+                        Color.userAccentColor.opacity(colorScheme == .dark ? 0.10 : 0.03)
+                    ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
                 )
             }
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
-        .overlay {
-            RoundedRectangle(cornerRadius: 28, style: .continuous)
-                .stroke(Color.userAccentColor.opacity(0.18))
+            .ignoresSafeArea(edges: .top)
         }
         .accessibilityElement(children: isEditing ? .contain : .combine)
         .accessibilityLabel(isEditing ? "Chest details" : "\(chest.name), \(usedSlots) of \(chest.size.rawValue) slots used")


### PR DESCRIPTION
### Motivation
- Replace the plain `.navigationTitle` title with the responsive chest hero so the detail view reads as a single, polished header area.
- Let the hero visually extend beneath the navigation area so the accent treatment feels integrated and full-width on larger layouts.
- Make the hero stronger in Dark Mode so the accent color remains noticeable without changing the overall design language.

### Description
- Updated `Craftify/ChestsView.swift` to remove the inline `navigationTitle` and make the hero the visible header by using `.toolbarBackground(.hidden, for: .navigationBar)` and letting the hero background extend under the top safe area with `.ignoresSafeArea(edges: .top)`.
- Kept the recipe grid content constrained and padded independently by wrapping the stored-recipes region in a `Group`, constraining it with `frame(maxWidth: 1200)` and separate `pagePadding` so the hero can remain full-width while content remains readable.
- Converted the header to be color-scheme aware by adding `@Environment(\.colorScheme)` and adjusting the gradient opacities (`Color.userAccentColor.opacity(...)`) so Dark Mode shows an increased accent presence.
- Small layout and accessibility tidy-ups to preserve edit states, transitions, and button styles while moving to the new header treatment.

### Testing
- Ran `git diff --check` which reported no local diff issues and passed.
- Verified repository status with `git status --short` which reflected the change to `Craftify/ChestsView.swift`.
- Attempted to run `xcodebuild` to build the app but the container lacks `xcodebuild`, so an on-device/CI build should be run to fully validate runtime visuals and safe-area behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6cffad80808320b4c4cde9b07c9d48)