### PR TITLE
Restore chest detail navigation bar scroll behavior

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -299,7 +299,9 @@ struct ChestDetailView: View {
                 }
                 .background(Color(.systemGroupedBackground))
                 .id(accentColorPreference).tint(Color.userAccentColor)
-                .toolbarBackground(.hidden, for: .navigationBar)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+                .toolbarBackground(.automatic, for: .navigationBar)
                 .toolbar {
                     Button(editMode.isEditing ? "Done" : "Edit", action: toggleEditMode)
                 }


### PR DESCRIPTION
### Motivation
- Prevent the chest detail hero from forcing a permanently transparent navigation bar which makes the back/Edit controls hard to read when the recipe grid scrolls underneath. 
- Ensure the detail destination keeps an inline title so it does not inherit the source screen’s large-title layout and reserve a blank large-title area.

### Description
- Updated `Craftify/ChestsView.swift` to use `navigationBarTitleDisplayMode(.inline)` for the chest detail destination. 
- Replaced the always-hidden bar style with `toolbarBackground(.ultraThinMaterial, for: .navigationBar)` plus `toolbarBackground(.automatic, for: .navigationBar)` so the navigation background restores automatically when the hero scrolls away. 
- Kept the hero visually behind transparent controls at the top while restoring contrast over the recipe grid after scrolling.

### Testing
- Ran `git diff --check` to validate there are no diff-check issues and it succeeded. 
- Executed a Python assertion script to verify the new modifiers (`.navigationBarTitleDisplayMode(.inline)` and the `toolbarBackground` calls) are present and the previous `.toolbarBackground(.hidden, ...)` is removed, and the assertions passed. 
- Attempted an `xcodebuild` test build but it could not run in this environment because `xcodebuild` is not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d02adede483209ba4077f6ad93920)