### PR TITLE
Unify hero navigation styling across Craftify

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -49,12 +49,15 @@ struct ChestsView: View {
                     .listStyle(.insetGrouped)
                 }
             }
-            .background(Color(.systemGroupedBackground))
+            .background(alignment: .top) {
+                AppHeroBackground()
+            }
             .id(accentColorPreference)
             .tint(Color.userAccentColor)
             .navigationTitle("Chests")
             .navigationBarTitleDisplayMode(.large)
             .toolbar(.visible, for: .navigationBar)
+            .toolbarBackground(.hidden, for: .navigationBar)
             .navigationDestination(for: UUID.self) { id in
                 if let chest = dataManager.chests.first(where: { $0.id == id }) {
                     ChestDetailView(chestID: chest.id, navigationPath: $navigationPath)
@@ -297,11 +300,12 @@ struct ChestDetailView: View {
                         .frame(maxWidth: .infinity)
                     }
                 }
-                .background(Color(.systemGroupedBackground))
+                .background(alignment: .top) {
+                    AppHeroBackground()
+                }
                 .id(accentColorPreference).tint(Color.userAccentColor)
                 .navigationBarTitleDisplayMode(.inline)
-                .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-                .toolbarBackground(.automatic, for: .navigationBar)
+                .toolbarBackground(.hidden, for: .navigationBar)
                 .toolbar {
                     Button(editMode.isEditing ? "Done" : "Edit", action: toggleEditMode)
                 }

--- a/Craftify/CommandsView.swift
+++ b/Craftify/CommandsView.swift
@@ -203,7 +203,9 @@ struct CommandsView: View {
                     dataManager.fetchConsoleCommands()
                 }
                 .scrollContentBackground(.hidden)
-                .background(Color(UIColor.systemGroupedBackground))
+                .background(alignment: .top) {
+                    AppHeroBackground()
+                }
                 .searchable(
                     text: $searchText,
                     placement: .navigationBarDrawer(displayMode: .always),
@@ -237,7 +239,7 @@ struct CommandsView: View {
                 }
                 .navigationTitle("Console Commands")
                 .navigationBarTitleDisplayMode(.large)
-                .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+                .toolbarBackground(.hidden, for: .navigationBar)
                 .safeAreaInset(edge: .top) { Color.clear.frame(height: 0) }
                 .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 0) }
                 .preferredColorScheme(

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -218,7 +218,7 @@ struct CategoryView: View {
             )
         }
         .background(alignment: .top) {
-            RecipesHeroBackground()
+            AppHeroBackground()
         }
         .navigationTitle("Craftify")
         .navigationBarTitleDisplayMode(.large)
@@ -302,18 +302,22 @@ struct CategoryFilterBar: View {
     }
 }
 
-private struct RecipesHeroBackground: View {
+struct AppHeroBackground: View {
     var body: some View {
-        LinearGradient(
-            colors: [
-                Color.userAccentColor.opacity(0.42),
-                Color.userAccentColor.opacity(0.18),
-                Color(.systemGroupedBackground)
-            ],
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
-        )
-        .frame(height: 190)
+        ZStack(alignment: .top) {
+            Color(.systemGroupedBackground)
+
+            LinearGradient(
+                colors: [
+                    Color.userAccentColor.opacity(0.42),
+                    Color.userAccentColor.opacity(0.18),
+                    Color(.systemGroupedBackground)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .frame(height: 190)
+        }
         .ignoresSafeArea(edges: .top)
         .accessibilityHidden(true)
     }

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -81,11 +81,13 @@ struct MoreView: View {
             .listStyle(.insetGrouped)
             .listSectionSpacing(24)
             .scrollContentBackground(.hidden)
-            .background(Color(.systemGroupedBackground))
+            .background(alignment: .top) {
+                AppHeroBackground()
+            }
             .tint(Color.userAccentColor)
             .navigationTitle("More")
             .navigationBarTitleDisplayMode(.large)
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarBackground(.hidden, for: .navigationBar)
             .alert("Unable to Sync", isPresented: errorBinding) {
                 Button("OK", role: .cancel) { dataManager.errorMessage = nil }
             } message: {
@@ -275,11 +277,13 @@ struct AboutView: View {
         }
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
-        .background(Color(.systemGroupedBackground))
+        .background(alignment: .top) {
+            AppHeroBackground()
+        }
         .tint(Color.userAccentColor)
         .navigationTitle("About Craftify")
         .navigationBarTitleDisplayMode(.large)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .toolbarBackground(.hidden, for: .navigationBar)
     }
 
     private func accentLabel(_ title: String, systemImage: String) -> some View {

--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -40,8 +40,8 @@ struct RecipeDetailView: View {
 
     var body: some View {
         ZStack {
-            Color(.systemGroupedBackground)
-                .ignoresSafeArea()
+            AppHeroBackground()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 
             RecipeDetailContent(
                 recipe: recipe,
@@ -67,7 +67,7 @@ struct RecipeDetailView: View {
         .navigationTitle(recipe.name)
         .navigationBarTitleDisplayMode(.large)
         .toolbar(.visible, for: .navigationBar)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .toolbarBackground(.hidden, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {

--- a/Craftify/RecipeSearchView.swift
+++ b/Craftify/RecipeSearchView.swift
@@ -221,7 +221,9 @@ struct RecipeSearchView: View {
                 .safeAreaInset(edge: .bottom, content: { Color.clear.frame(height: 0) })
             }
             .scrollContentBackground(.hidden)
-            .background(Color(.systemGroupedBackground).ignoresSafeArea())
+            .background(alignment: .top) {
+                AppHeroBackground()
+            }
             .id(accentColorPreference)
             .overlay {
                 if dataManager.isLoading && dataManager.recipes.isEmpty {
@@ -243,7 +245,7 @@ struct RecipeSearchView: View {
             .navigationTitle("Search")
             .navigationBarTitleDisplayMode(.large)
             .toolbar(.visible, for: .navigationBar)
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .toolbarBackground(.hidden, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Menu {

--- a/Craftify/ReleaseNotesView.swift
+++ b/Craftify/ReleaseNotesView.swift
@@ -75,10 +75,12 @@ struct ReleaseNotesView: View {
         .id(accentColorPreference)
         .listStyle(InsetGroupedListStyle())
         .scrollContentBackground(.hidden)
-        .background(Color(.systemGroupedBackground))
+        .background(alignment: .top) {
+            AppHeroBackground()
+        }
         .navigationTitle("Release Notes")
         .navigationBarTitleDisplayMode(.large)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .toolbarBackground(.hidden, for: .navigationBar)
         .dynamicTypeSize(.xSmall ... .accessibility5)
     }
 }

--- a/Craftify/ReportRecipeView.swift
+++ b/Craftify/ReportRecipeView.swift
@@ -77,7 +77,8 @@ struct ReportRecipeView: View {
     private var isSubmissionOnCooldown: Bool { remainingSubmissionCooldown > 0 }
     var body: some View {
         ZStack {
-            Color(uiColor: .systemGroupedBackground).ignoresSafeArea()
+            AppHeroBackground()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
 
             ScrollView {
                 LazyVStack(spacing: 20) {
@@ -135,7 +136,7 @@ struct ReportRecipeView: View {
         }
         .navigationTitle("Report a Recipe")
         .navigationBarTitleDisplayMode(.large)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .toolbarBackground(.hidden, for: .navigationBar)
         .alert("Delete report?", isPresented: $showDeleteConfirmation) {
             Button("Delete", role: .destructive) {
                 if let reportToDelete { deleteReport(reportToDelete) }

--- a/Craftify/SupportView.swift
+++ b/Craftify/SupportView.swift
@@ -124,8 +124,10 @@ struct SupportView: View {
             .scrollContentBackground(.hidden)
             .navigationTitle("Support & Privacy")
             .navigationBarTitleDisplayMode(.large)
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-            .background(Color(UIColor.systemGroupedBackground))
+            .toolbarBackground(.hidden, for: .navigationBar)
+            .background(alignment: .top) {
+                AppHeroBackground()
+            }
             .alert(isPresented: $showErrorAlert) {
                 Alert(
                     title: Text("Error"),


### PR DESCRIPTION
### Motivation

- Make the app's top bar/hero styling consistent by promoting the recipe hero into a reusable component that blends the accent gradient with the grouped background. 
- Allow the accent hero to extend behind navigation bars so screens share a consistent visual transition and avoid stacked headers. 
- Apply the new, transparent navigation-bar treatment across all primary views and nested screens for a cohesive UI.

### Description

- Introduced a reusable `AppHeroBackground` view (extracted from the recipes hero) that composes a grouped background with the accent gradient and ignores the top safe area. 
- Replaced local hero/backdrop usages with `AppHeroBackground()` in `ContentView.swift`, `ChestsView.swift`, `MoreView.swift`, `RecipeDetailView.swift`, `RecipeSearchView.swift`, `ReportRecipeView.swift`, `CommandsView.swift`, `ReleaseNotesView.swift`, and `SupportView.swift`. 
- Switched several screens to use `.background(alignment: .top) { AppHeroBackground() }` (or a top-aligned `AppHeroBackground()` frame) so the hero visually sits behind content. 
- Unified navigation bar behavior by setting `.toolbarBackground(.hidden, for: .navigationBar)` on the updated views so the system-managed titles and controls sit above the hero while preserving accessibility and title behavior. 

### Testing

- Ran `git diff --check` to ensure no whitespace/patch issues, which completed without errors. 
- Executed a Python verification script that checks each requested screen contains `AppHeroBackground()` and `.toolbarBackground(.hidden, for: .navigationBar)`, which passed. 
- Attempted `xcodebuild -project Craftify.xcodeproj -scheme Craftify ...`, but the container does not provide Xcode so the build could not be run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d13f0a8d083208df108ac5b865c48)