### PR TITLE
Adapt hero backgrounds to real navigation geometry

### DIFF
--- a/Craftify/AppAppearanceView.swift
+++ b/Craftify/AppAppearanceView.swift
@@ -152,7 +152,7 @@ struct AppAppearanceView: View {
         .navigationTitle("App Appearance")
         .navigationBarTitleDisplayMode(.large)
         .tint(selectedAccentColor)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .toolbarBackground(.hidden, for: .navigationBar)
         .safeAreaInset(edge: .top, content: { Color.clear.frame(height: 0) })
         .safeAreaInset(edge: .bottom, content: { Color.clear.frame(height: 0) })
         .alert("Error",

--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -47,6 +47,7 @@ struct ChestsView: View {
                         }
                     }
                     .listStyle(.insetGrouped)
+                    .scrollContentBackground(.hidden)
                 }
             }
             .background(alignment: .top) {
@@ -300,9 +301,6 @@ struct ChestDetailView: View {
                         .frame(maxWidth: .infinity)
                     }
                 }
-                .background(alignment: .top) {
-                    AppHeroBackground()
-                }
                 .id(accentColorPreference).tint(Color.userAccentColor)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbarBackground(.hidden, for: .navigationBar)
@@ -375,6 +373,9 @@ private struct ChestDetailHeader: View {
         .padding(.vertical, 24)
         .frame(maxWidth: .infinity)
         .background {
+            // The fill mode lets one uninterrupted hero extend from behind the
+            // navigation controls through the complete, dynamically sized
+            // chest header.
             AppHeroBackground(additionalHeight: nil)
         }
         .accessibilityElement(children: isEditing ? .contain : .combine)

--- a/Craftify/ColorExtension.swift
+++ b/Craftify/ColorExtension.swift
@@ -21,7 +21,13 @@ extension Color {
     static var userAccentColor: Color {
         let defaults = UserDefaults.standard
         let preference = defaults.string(forKey: "accentColorPreference") ?? "default"
-        
+
+        return userAccentColor(for: preference)
+    }
+
+    /// Resolves an accent directly from the observed preference. This avoids a
+    /// second UserDefaults read when a view is already driven by `@AppStorage`.
+    static func userAccentColor(for preference: String) -> Color {
         switch preference {
         case "blue":
             return .blue

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -305,10 +305,9 @@ struct CategoryFilterBar: View {
 }
 
 struct AppHeroBackground: View {
-    private static let navigationHeight: CGFloat = 112
-
-    /// The portion of the receiving view, below the navigation bar, that the
-    /// hero should cover. Most screens should use the navigation-only default.
+    /// The portion below the actual top safe area/navigation region that the
+    /// hero should cover. Passing `nil` fills the receiving view, which is
+    /// useful when a custom header is part of the hero.
     let additionalHeight: CGFloat?
 
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
@@ -318,21 +317,38 @@ struct AppHeroBackground: View {
     }
 
     var body: some View {
-        LinearGradient(
-            colors: [
-                Color.userAccentColor.opacity(0.42),
-                Color.userAccentColor.opacity(0.18),
-                Color(.systemGroupedBackground)
-            ],
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
-        )
-        .frame(maxWidth: .infinity)
-        .frame(height: additionalHeight.map { Self.navigationHeight + $0 })
+        GeometryReader { geometry in
+            // Depending on its container, SwiftUI either reports the whole
+            // navigation region as a safe-area inset or positions the content
+            // below it. Taking the larger measurement handles both layouts,
+            // including taller Dynamic Island safe areas and large titles.
+            let navigationRegionHeight = max(
+                geometry.safeAreaInsets.top,
+                max(geometry.frame(in: .global).minY, 0)
+            )
+            let heroHeight = additionalHeight.map { navigationRegionHeight + $0 }
+                ?? (geometry.size.height + navigationRegionHeight)
+
+            ZStack(alignment: .top) {
+                // Lists and scroll views deliberately hide their native
+                // grouped background. Keep everything below the hero on the
+                // standard app surface rather than leaving it transparent.
+                Color(.systemBackground)
+
+                LinearGradient(
+                    colors: [
+                        Color.userAccentColor(for: accentColorPreference).opacity(0.42),
+                        Color.userAccentColor(for: accentColorPreference).opacity(0.18),
+                        Color(.systemBackground)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                .frame(maxWidth: .infinity)
+                .frame(height: heroHeight)
+            }
+        }
         .ignoresSafeArea(edges: .top)
-        // AppStorage makes the shared hero redraw as soon as the preference
-        // changes instead of waiting for its parent view to be recreated.
-        .id(accentColorPreference)
         .accessibilityHidden(true)
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure the app hero gradient sizes correctly on devices with tall safe areas / large-title nav bars instead of relying on a fixed 112‑point constant.
- Stop hero regions from exposing the wrong underlying surface by making them render onto `systemBackground` so lists and forms no longer show awkward transitions.
- Make the chest screens and chest detail header form a single continuous hero region that includes the large-title area and chest header.
- Ensure accent color updates are resolved consistently and immediately when `accentColorPreference` changes.

### Description

- Reimplemented `AppHeroBackground` to size itself from container geometry using `GeometryReader`, combining `geometry.safeAreaInsets.top` and `geometry.frame(in: .global).minY` to compute the navigation region height and derive the hero height, and to fill the shared surface with `Color(.systemBackground)` beneath the gradient.
- Reworked accent resolution by adding `Color.userAccentColor(for:)` and making `Color.userAccentColor` call it, so views driven by `@AppStorage` can obtain the accent without a second `UserDefaults` read and the hero renders with the observed preference.
- Applied the hero as a fill-mode background for the Chest detail header and removed the competing background on the chest detail scroll content so the navigation bar, chest icon, title and slot UI form one continuous hero region.
- Enabled `.scrollContentBackground(.hidden)` on the Chests list so the hero shows through while preserving inset grouped row styling.
- Switched the App Appearance screen to use `.toolbarBackground(.hidden, for: .navigationBar)` so its large title sits directly over the hero like other screens.
- Cleaned up `AppHeroBackground`’s redraw behavior by resolving colors from the observed preference rather than relying on an `.id(...)` redraw hack.

### Testing

- Parsed the modified Swift sources successfully with `swiftc -frontend -parse Craftify/ContentView.swift Craftify/ColorExtension.swift Craftify/ChestsView.swift Craftify/AppAppearanceView.swift` (success).
- Verified repository formatting and diffs with `git diff --check` (no issues) and inspected `git status` and `git diff` (changes staged and committed).
- Attempted an `xcodebuild` iOS simulator build but Xcode was not available in the Linux environment, so a full Xcode build / runtime verification could not be executed here (environment limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d1bd8f0588320acda3439eea1f849)