### PR TITLE
Restore native navigation backgrounds outside the home view

### DIFF
--- a/Craftify/AppAppearanceView.swift
+++ b/Craftify/AppAppearanceView.swift
@@ -146,13 +146,11 @@ struct AppAppearanceView: View {
         }
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
-        .background(alignment: .top) {
-            AppHeroBackground()
-        }
+        .background(Color(.systemGroupedBackground))
         .navigationTitle("App Appearance")
         .navigationBarTitleDisplayMode(.large)
         .tint(selectedAccentColor)
-        .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .safeAreaInset(edge: .top, content: { Color.clear.frame(height: 0) })
         .safeAreaInset(edge: .bottom, content: { Color.clear.frame(height: 0) })
         .alert("Error",

--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -47,18 +47,14 @@ struct ChestsView: View {
                         }
                     }
                     .listStyle(.insetGrouped)
-                    .scrollContentBackground(.hidden)
                 }
             }
-            .background(alignment: .top) {
-                AppHeroBackground()
-            }
+            .background(Color(.systemGroupedBackground))
             .id(accentColorPreference)
             .tint(Color.userAccentColor)
             .navigationTitle("Chests")
             .navigationBarTitleDisplayMode(.large)
             .toolbar(.visible, for: .navigationBar)
-            .toolbarBackground(.hidden, for: .navigationBar)
             .navigationDestination(for: UUID.self) { id in
                 if let chest = dataManager.chests.first(where: { $0.id == id }) {
                     ChestDetailView(chestID: chest.id, navigationPath: $navigationPath)
@@ -253,53 +249,54 @@ struct ChestDetailView: View {
                             isEditing: editMode.isEditing,
                             name: $chestName
                         )
-                        Group {
-                            if storedRecipes.isEmpty {
-                                ContentUnavailableView {
-                                    Label("No Stored Recipes", systemImage: "square.grid.3x3")
-                                } description: {
-                                    Text("Open a recipe and use the add button to store it in this chest.")
-                                }
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 36)
-                            } else {
-                                VStack(alignment: .leading, spacing: 12) {
-                                    Text("Stored Recipes")
-                                        .font(.title2.bold())
-                                        .accessibilityAddTraits(.isHeader)
+                        if storedRecipes.isEmpty {
+                            ContentUnavailableView {
+                                Label("No Stored Recipes", systemImage: "square.grid.3x3")
+                            } description: {
+                                Text("Open a recipe and use the add button to store it in this chest.")
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 36)
+                        } else {
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text("Stored Recipes")
+                                    .font(.title2.bold())
+                                    .accessibilityAddTraits(.isHeader)
 
-                                    LazyVGrid(columns: gridColumns, spacing: cardSpacing) {
-                                        ForEach(Array(storedRecipes.enumerated()), id: \.element.id) { slot, recipe in
-                                            ZStack(alignment: .topTrailing) {
-                                                NavigationLink(value: recipe) {
-                                                    ChestRecipeCard(recipe: recipe, slot: slot + 1)
-                                                }
-                                                .buttonStyle(.plain)
+                                LazyVGrid(columns: gridColumns, spacing: cardSpacing) {
+                                    ForEach(Array(storedRecipes.enumerated()), id: \.element.id) { slot, recipe in
+                                        ZStack(alignment: .topTrailing) {
+                                            NavigationLink(value: recipe) {
+                                                ChestRecipeCard(recipe: recipe, slot: slot + 1)
+                                            }
+                                            .buttonStyle(.plain)
 
-                                                if editMode.isEditing {
-                                                    Button("Remove \(recipe.name)", systemImage: "minus.circle.fill") {
-                                                        dataManager.removeRecipes(withIDs: [recipe.id], from: chestID)
-                                                        HapticFeedback.impact()
-                                                    }
-                                                    .labelStyle(.iconOnly)
-                                                    .font(.title2)
-                                                    .foregroundStyle(.white, .red)
-                                                    .frame(minWidth: 44, minHeight: 44)
-                                                    .contentShape(Rectangle())
-                                                    .accessibilityHint("Removes this recipe from \(chest.name)")
-                                                    .transition(reduceMotion ? .opacity : .scale.combined(with: .opacity))
+                                            if editMode.isEditing {
+                                                Button("Remove \(recipe.name)", systemImage: "minus.circle.fill") {
+                                                    dataManager.removeRecipes(withIDs: [recipe.id], from: chestID)
+                                                    HapticFeedback.impact()
                                                 }
+                                                .labelStyle(.iconOnly)
+                                                .font(.title2)
+                                                .foregroundStyle(.white, .red)
+                                                .frame(minWidth: 44, minHeight: 44)
+                                                .contentShape(Rectangle())
+                                                .accessibilityHint("Removes this recipe from \(chest.name)")
+                                                .transition(reduceMotion ? .opacity : .scale.combined(with: .opacity))
                                             }
                                         }
                                     }
                                 }
                             }
                         }
-                        .frame(maxWidth: 1200)
-                        .padding(.horizontal, pagePadding)
-                        .padding(.bottom, pagePadding)
-                        .frame(maxWidth: .infinity)
                     }
+                    .frame(maxWidth: 1200)
+                    .padding(pagePadding)
+                    .frame(maxWidth: .infinity)
+                }
+                .background {
+                    ChestDetailBackground()
+                        .ignoresSafeArea()
                 }
                 .id(accentColorPreference).tint(Color.userAccentColor)
                 .navigationBarTitleDisplayMode(.inline)
@@ -368,16 +365,8 @@ private struct ChestDetailHeader: View {
                 details(centered: true)
             }
         }
-        .frame(maxWidth: 1200)
-        .padding(.horizontal, 20)
-        .padding(.vertical, 24)
+        .padding(20)
         .frame(maxWidth: .infinity)
-        .background {
-            // The fill mode lets one uninterrupted hero extend from behind the
-            // navigation controls through the complete, dynamically sized
-            // chest header.
-            AppHeroBackground(additionalHeight: nil)
-        }
         .accessibilityElement(children: isEditing ? .contain : .combine)
         .accessibilityLabel(isEditing ? "Chest details" : "\(chest.name), \(usedSlots) of \(chest.size.rawValue) slots used")
     }
@@ -420,6 +409,22 @@ private struct ChestDetailHeader: View {
                 .accessibilityValue("\(usedSlots) of \(chest.size.rawValue) slots used")
         }
         .frame(maxWidth: .infinity, alignment: centered ? .center : .leading)
+    }
+}
+
+private struct ChestDetailBackground: View {
+    var body: some View {
+        ZStack {
+            Color(.systemBackground)
+            LinearGradient(
+                colors: [
+                    Color.userAccentColor.opacity(0.20),
+                    Color.userAccentColor.opacity(0.03)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        }
     }
 }
 

--- a/Craftify/CommandsView.swift
+++ b/Craftify/CommandsView.swift
@@ -203,9 +203,7 @@ struct CommandsView: View {
                     dataManager.fetchConsoleCommands()
                 }
                 .scrollContentBackground(.hidden)
-                .background(alignment: .top) {
-                    AppHeroBackground()
-                }
+                .background(Color(UIColor.systemGroupedBackground))
                 .searchable(
                     text: $searchText,
                     placement: .navigationBarDrawer(displayMode: .always),
@@ -239,7 +237,7 @@ struct CommandsView: View {
                 }
                 .navigationTitle("Console Commands")
                 .navigationBarTitleDisplayMode(.large)
-                .toolbarBackground(.hidden, for: .navigationBar)
+                .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
                 .safeAreaInset(edge: .top) { Color.clear.frame(height: 0) }
                 .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 0) }
                 .preferredColorScheme(

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -81,13 +81,11 @@ struct MoreView: View {
             .listStyle(.insetGrouped)
             .listSectionSpacing(24)
             .scrollContentBackground(.hidden)
-            .background(alignment: .top) {
-                AppHeroBackground()
-            }
+            .background(Color(.systemGroupedBackground))
             .tint(Color.userAccentColor)
             .navigationTitle("More")
             .navigationBarTitleDisplayMode(.large)
-            .toolbarBackground(.hidden, for: .navigationBar)
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
             .alert("Unable to Sync", isPresented: errorBinding) {
                 Button("OK", role: .cancel) { dataManager.errorMessage = nil }
             } message: {
@@ -277,13 +275,11 @@ struct AboutView: View {
         }
         .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
-        .background(alignment: .top) {
-            AppHeroBackground()
-        }
+        .background(Color(.systemGroupedBackground))
         .tint(Color.userAccentColor)
         .navigationTitle("About Craftify")
         .navigationBarTitleDisplayMode(.large)
-        .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
     }
 
     private func accentLabel(_ title: String, systemImage: String) -> some View {

--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -40,8 +40,8 @@ struct RecipeDetailView: View {
 
     var body: some View {
         ZStack {
-            AppHeroBackground()
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            Color(.systemGroupedBackground)
+                .ignoresSafeArea()
 
             RecipeDetailContent(
                 recipe: recipe,
@@ -67,7 +67,7 @@ struct RecipeDetailView: View {
         .navigationTitle(recipe.name)
         .navigationBarTitleDisplayMode(.large)
         .toolbar(.visible, for: .navigationBar)
-        .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {

--- a/Craftify/RecipeSearchView.swift
+++ b/Craftify/RecipeSearchView.swift
@@ -221,9 +221,7 @@ struct RecipeSearchView: View {
                 .safeAreaInset(edge: .bottom, content: { Color.clear.frame(height: 0) })
             }
             .scrollContentBackground(.hidden)
-            .background(alignment: .top) {
-                AppHeroBackground()
-            }
+            .background(Color(.systemGroupedBackground).ignoresSafeArea())
             .id(accentColorPreference)
             .overlay {
                 if dataManager.isLoading && dataManager.recipes.isEmpty {
@@ -245,7 +243,7 @@ struct RecipeSearchView: View {
             .navigationTitle("Search")
             .navigationBarTitleDisplayMode(.large)
             .toolbar(.visible, for: .navigationBar)
-            .toolbarBackground(.hidden, for: .navigationBar)
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Menu {

--- a/Craftify/ReleaseNotesView.swift
+++ b/Craftify/ReleaseNotesView.swift
@@ -75,12 +75,10 @@ struct ReleaseNotesView: View {
         .id(accentColorPreference)
         .listStyle(InsetGroupedListStyle())
         .scrollContentBackground(.hidden)
-        .background(alignment: .top) {
-            AppHeroBackground()
-        }
+        .background(Color(.systemGroupedBackground))
         .navigationTitle("Release Notes")
         .navigationBarTitleDisplayMode(.large)
-        .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .dynamicTypeSize(.xSmall ... .accessibility5)
     }
 }

--- a/Craftify/ReportRecipeView.swift
+++ b/Craftify/ReportRecipeView.swift
@@ -77,8 +77,7 @@ struct ReportRecipeView: View {
     private var isSubmissionOnCooldown: Bool { remainingSubmissionCooldown > 0 }
     var body: some View {
         ZStack {
-            AppHeroBackground()
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+            Color(uiColor: .systemGroupedBackground).ignoresSafeArea()
 
             ScrollView {
                 LazyVStack(spacing: 20) {
@@ -136,7 +135,7 @@ struct ReportRecipeView: View {
         }
         .navigationTitle("Report a Recipe")
         .navigationBarTitleDisplayMode(.large)
-        .toolbarBackground(.hidden, for: .navigationBar)
+        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .alert("Delete report?", isPresented: $showDeleteConfirmation) {
             Button("Delete", role: .destructive) {
                 if let reportToDelete { deleteReport(reportToDelete) }

--- a/Craftify/SupportView.swift
+++ b/Craftify/SupportView.swift
@@ -124,10 +124,8 @@ struct SupportView: View {
             .scrollContentBackground(.hidden)
             .navigationTitle("Support & Privacy")
             .navigationBarTitleDisplayMode(.large)
-            .toolbarBackground(.hidden, for: .navigationBar)
-            .background(alignment: .top) {
-                AppHeroBackground()
-            }
+            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .background(Color(UIColor.systemGroupedBackground))
             .alert(isPresented: $showErrorAlert) {
                 Alert(
                     title: Text("Error"),


### PR DESCRIPTION
### Motivation

- Keep the home view hero treatment isolated to the launcher and restore native navigation/material backgrounds elsewhere to improve readability. 
- Replace ad-hoc hero fills in list/detail screens with the system grouped/background colors so lists and forms no longer appear plain white. 
- For chest details, experiment with applying the accent gradient across the full screen while keeping the navigation background visually transparent.

### Description

- Removed `AppHeroBackground` usages from non-home screens and replaced them with `Color(.systemGroupedBackground)` or `.ignoresSafeArea()` backgrounds in views such as `AppAppearanceView`, `CommandsView`, `MoreView`, `RecipeDetailView`, `RecipeSearchView`, `ReleaseNotesView`, `ReportRecipeView`, `SupportView`, and `ChestsView`.
- Restored native navigation styling in those views by using `.toolbarBackground(.ultraThinMaterial, for: .navigationBar)` (replacing hidden hero navigation backgrounds) so the system material/nav appearance is used again.
- Reworked `ChestDetailView` to apply a new `ChestDetailBackground` (accent gradient + system background) that fills the entire screen, removed the header’s standalone colored card decoration, and kept the chest detail navigation background visually transparent so back/edit controls remain available but not hero-filled.
- Left `AppHeroBackground` implementation and its use intact in `ContentView.swift` only and adjusted a few layout/padding changes in `ChestsView` and chest header to match the new full-screen fill behavior.

### Testing

- Ran `git diff --cached --check` to validate staged changes and observed no style/check errors.
- Verified `AppHeroBackground` references are limited to `Craftify/ContentView.swift` using a repository search (`rg`) and checked for replaced background/toolbar usages across modified files.
- Attempted to run `xcodebuild -project Craftify.xcodeproj -scheme Craftify -sdk iphonesimulator -configuration Debug build CODE_SIGNING_ALLOWED=NO` to validate a full build, but `xcodebuild` is unavailable in this environment so an actual build could not be performed.
- No automated UI/screenshot tests were run because an iOS simulator is not available in this Linux environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d2164d7d48320b9d80fc8b6a18ac6)