### PR TITLE
Promote ChestDetailView background into shared AppBackground

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -302,7 +302,7 @@ struct ChestDetailView: View {
                     .frame(maxWidth: .infinity)
                 }
                 .background {
-                    ChestDetailBackground()
+                    AppBackground()
                         .ignoresSafeArea()
                 }
                 .id(accentColorPreference).tint(Color.userAccentColor)
@@ -419,22 +419,6 @@ private struct ChestDetailHeader: View {
     }
 }
 
-private struct ChestDetailBackground: View {
-    var body: some View {
-        ZStack {
-            Color(.systemBackground)
-            LinearGradient(
-                colors: [
-                    Color.userAccentColor.opacity(0.20),
-                    Color.userAccentColor.opacity(0.03)
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-        }
-    }
-}
-
 private struct ChestRecipeCard: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     let recipe: Recipe
@@ -442,7 +426,7 @@ private struct ChestRecipeCard: View {
     var body: some View {
         VStack(spacing: 0) {
             ZStack(alignment: .topLeading) {
-                Color(.systemBackground)
+                AppBackground()
                 Image(recipe.image)
                     .resizable()
                     .scaledToFit()

--- a/Craftify/ColorExtension.swift
+++ b/Craftify/ColorExtension.swift
@@ -58,3 +58,24 @@ extension Color {
         }
     }
 }
+
+/// The shared app surface, matching the accent-tinted background introduced
+/// by the chest detail screen.
+struct AppBackground: View {
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
+
+    var body: some View {
+        ZStack {
+            Color(.systemBackground)
+            LinearGradient(
+                colors: [
+                    Color.userAccentColor(for: accentColorPreference).opacity(0.20),
+                    Color.userAccentColor(for: accentColorPreference).opacity(0.03)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        }
+        .accessibilityHidden(true)
+    }
+}

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -332,14 +332,15 @@ struct AppHeroBackground: View {
             ZStack(alignment: .top) {
                 // Lists and scroll views deliberately hide their native
                 // grouped background. Keep everything below the hero on the
-                // standard app surface rather than leaving it transparent.
-                Color(.systemBackground)
+                // shared accent-tinted app surface rather than leaving it
+                // transparent.
+                AppBackground()
 
                 LinearGradient(
                     colors: [
                         Color.userAccentColor(for: accentColorPreference).opacity(0.42),
                         Color.userAccentColor(for: accentColorPreference).opacity(0.18),
-                        Color(.systemBackground)
+                        Color.clear
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing

--- a/Craftify/CraftifyApp.swift
+++ b/Craftify/CraftifyApp.swift
@@ -18,7 +18,7 @@ struct CraftifyApp: App {
                 tabBarAppearance.configureWithTransparentBackground()
                 let blurEffect = UIBlurEffect(style: .systemUltraThinMaterial)
                 tabBarAppearance.backgroundEffect = blurEffect
-                tabBarAppearance.backgroundColor = UIColor.systemBackground.withAlphaComponent(0.1)
+                tabBarAppearance.backgroundColor = .clear
         } else {
             tabBarAppearance.configureWithDefaultBackground()
         }

--- a/Craftify/ReleaseNotesView.swift
+++ b/Craftify/ReleaseNotesView.swift
@@ -51,7 +51,7 @@ struct ReleaseNotesView: View {
                 .accessibilityValue("\(appVersion). Stay updated with the latest improvements, fixes, and new features.")
                 .accessibilityHint("Release notes overview")
             }
-            .listRowBackground(Color(UIColor.systemBackground))
+            .listRowBackground(AppBackground())
             
             ForEach(releaseNotes, id: \.version) { note in
                 Section(header: Text(note.version)


### PR DESCRIPTION
### Motivation
- Replace scattered uses of `systemBackground` with the updated accent-tinted surface introduced in `ChestDetailView` so the app has a consistent, accent-aware backdrop.
- Make the chest detail screen’s layered gradient reusable across other UI surfaces that previously used the default system background.

### Description
- Introduce a new reusable `AppBackground` view that composes `Color(.systemBackground)` with the chest-detail accent gradient and respects `accentColorPreference` via `@AppStorage` (added to `Craftify/ColorExtension.swift`).
- Replace `ChestDetailBackground` usages with `AppBackground` in `Craftify/ChestsView.swift` and remove the previous `ChestDetailBackground` implementation.
- Use `AppBackground` for recipe card surfaces in `ChestRecipeCard` (in `ChestsView.swift`).
- Swap the hero surface and gradient composition in `ContentView.swift` to sit on top of `AppBackground` and change the hero’s trailing gradient stop to `Color.clear` to let the shared surface show through.
- Use `AppBackground` for the Release Notes header row background in `ReleaseNotesView.swift`.
- Make the Liquid Glass tab bar background clear so the new app surface can be visible beneath it (tweak in `CraftifyApp.swift`).

### Testing
- Ran `git diff --check` and it completed without reported whitespace errors.
- Audited Swift sources with `rg` to confirm the only remaining `systemBackground` reference is the adaptive base color inside `AppBackground` (search: `rg -n 'Color\(\.systemBackground\)|UIColor\.systemBackground' Craftify --glob '*.swift'`).
- Attempted an iOS build but `xcodebuild` is unavailable in this Linux environment, so a simulator build/screenshot was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6d473440c483208568bedcb2bb4273)