### PR TITLE
Load shared recipe images from CloudKit

### DIFF
--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -427,8 +427,7 @@ private struct ChestRecipeCard: View {
         VStack(spacing: 0) {
             ZStack(alignment: .topLeading) {
                 AppBackground()
-                Image(recipe.image)
-                    .resizable()
+                CraftImage(key: recipe.image)
                     .scaledToFit()
                     .padding(18)
                 Text("\(slot)")

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -472,8 +472,7 @@ struct RecipeCell: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Image(recipe.image)
-                .resizable()
+            CraftImage(key: recipe.image)
                 .scaledToFit()
                 .frame(
                     width: isCraftifyPick

--- a/Craftify/CraftImageStore.swift
+++ b/Craftify/CraftImageStore.swift
@@ -1,0 +1,341 @@
+//
+//  CraftImageStore.swift
+//  Craftify
+//
+//  CloudKit-backed shared image library with bundled and disk fallbacks.
+//
+
+import Foundation
+import SwiftUI
+import UIKit
+@preconcurrency import CloudKit
+
+enum CraftImageAssetKey {
+    static let recordType = "CraftImageAsset"
+    static let assetKeyField = "assetKey"
+    static let fileField = "file"
+    static let versionField = "version"
+
+    static func recordName(for assetKey: String) -> String {
+        let encoded = Data(assetKey.utf8)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return "asset-\(encoded)"
+    }
+}
+
+@MainActor
+final class CraftImageStore: ObservableObject {
+    static let shared = CraftImageStore()
+
+    private let database: CKDatabase
+    private let fileManager: FileManager
+    private let defaults: UserDefaults
+    private let cacheDirectory: URL
+    private let imageCache = NSCache<NSString, UIImage>()
+    private var loadingKeys: Set<String> = []
+    private var lastChecked: [String: Date] = [:]
+
+    private let queryBatchSize = 100
+    private let refreshInterval: TimeInterval = 15 * 60
+
+    init(
+        containerIdentifier: String = "iCloud.craftifydb",
+        fileManager: FileManager = .default,
+        defaults: UserDefaults = .standard
+    ) {
+        self.database = CKContainer(identifier: containerIdentifier).publicCloudDatabase
+        self.fileManager = fileManager
+        self.defaults = defaults
+
+        let root = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        self.cacheDirectory = root.appendingPathComponent("CraftImageAssets", isDirectory: true)
+        try? fileManager.createDirectory(
+            at: cacheDirectory,
+            withIntermediateDirectories: true
+        )
+
+        imageCache.countLimit = 300
+    }
+
+    func image(for assetKey: String) -> UIImage? {
+        let cacheKey = assetKey as NSString
+        if let image = imageCache.object(forKey: cacheKey) {
+            return image
+        }
+
+        if let image = UIImage(contentsOfFile: cachedFileURL(for: assetKey).path) {
+            imageCache.setObject(image, forKey: cacheKey)
+            return image
+        }
+
+        return UIImage(named: assetKey)
+    }
+
+    func prefetch(recipes: [Recipe]) {
+        let keys = Self.imageKeys(in: recipes)
+        Task { [weak self] in
+            await self?.synchronize(keys: keys)
+        }
+    }
+
+    func load(_ assetKey: String) async {
+        let trimmed = assetKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        await synchronize(keys: [assetKey])
+    }
+
+    static func imageKeys(in recipes: [Recipe]) -> Set<String> {
+        var keys: Set<String> = []
+
+        func insert(_ value: String?) {
+            guard let value,
+                  !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return
+            }
+            keys.insert(value)
+        }
+
+        for recipe in recipes {
+            insert(recipe.image)
+            insert(recipe.imageremark)
+
+            let ingredientSets = [
+                recipe.ingredients,
+                recipe.alternateIngredients ?? [],
+                recipe.alternateIngredients1 ?? [],
+                recipe.alternateIngredients2 ?? [],
+                recipe.alternateIngredients3 ?? []
+            ]
+
+            for ingredientSet in ingredientSets {
+                ingredientSet.forEach { insert($0) }
+            }
+        }
+
+        return keys
+    }
+
+    private func synchronize(keys: Set<String>) async {
+        let usableKeys = Set(keys.filter {
+            !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        })
+        let now = Date()
+        let dueKeys = usableKeys.filter { key in
+            guard !loadingKeys.contains(key) else { return false }
+            guard let checked = lastChecked[key] else { return true }
+            return now.timeIntervalSince(checked) >= refreshInterval
+        }
+
+        guard !dueKeys.isEmpty else { return }
+
+        let requestedKeys = Set(dueKeys)
+        loadingKeys.formUnion(requestedKeys)
+        defer { loadingKeys.subtract(requestedKeys) }
+
+        let sortedKeys = requestedKeys.sorted()
+        for start in stride(from: 0, to: sortedKeys.count, by: queryBatchSize) {
+            let end = min(start + queryBatchSize, sortedKeys.count)
+            let batch = Array(sortedKeys[start..<end])
+            await synchronize(batch: batch)
+        }
+    }
+
+    private func synchronize(batch: [String]) async {
+        let predicate = NSPredicate(
+            format: "%K IN %@",
+            CraftImageAssetKey.assetKeyField,
+            batch
+        )
+        let metadataQuery = CKQuery(
+            recordType: CraftImageAssetKey.recordType,
+            predicate: predicate
+        )
+
+        do {
+            let metadataRecords = try await fetchAllRecords(
+                matching: metadataQuery,
+                desiredKeys: [
+                    CraftImageAssetKey.assetKeyField,
+                    CraftImageAssetKey.versionField
+                ]
+            )
+
+            let metadata = metadataRecords.reduce(into: [String: Int64]()) { result, record in
+                guard let key = record[CraftImageAssetKey.assetKeyField] as? String else {
+                    return
+                }
+                let version = record[CraftImageAssetKey.versionField] as? Int64 ?? 1
+                result[key] = max(result[key] ?? 0, version)
+            }
+
+            let returnedKeys = Set(metadata.keys)
+            var cacheChanged = false
+
+            for key in batch where !returnedKeys.contains(key) && localVersion(for: key) > 0 {
+                removeCachedRemoteImage(for: key)
+                cacheChanged = true
+            }
+
+            let outdatedKeys = metadata.compactMap { key, remoteVersion -> String? in
+                let hasValidFile = UIImage(contentsOfFile: cachedFileURL(for: key).path) != nil
+                return localVersion(for: key) < remoteVersion || !hasValidFile ? key : nil
+            }
+
+            if !outdatedKeys.isEmpty {
+                let assetPredicate = NSPredicate(
+                    format: "%K IN %@",
+                    CraftImageAssetKey.assetKeyField,
+                    outdatedKeys
+                )
+                let assetQuery = CKQuery(
+                    recordType: CraftImageAssetKey.recordType,
+                    predicate: assetPredicate
+                )
+                let assetRecords = try await fetchAllRecords(
+                    matching: assetQuery,
+                    desiredKeys: [
+                        CraftImageAssetKey.assetKeyField,
+                        CraftImageAssetKey.fileField,
+                        CraftImageAssetKey.versionField
+                    ]
+                )
+
+                for record in assetRecords {
+                    if try store(record: record) {
+                        cacheChanged = true
+                    }
+                }
+            }
+
+            let checkedAt = Date()
+            batch.forEach { lastChecked[$0] = checkedAt }
+
+            if cacheChanged {
+                objectWillChange.send()
+            }
+        } catch {
+            let checkedAt = Date()
+            batch.forEach { lastChecked[$0] = checkedAt }
+            print("Craft image sync failed: \(error.localizedDescription)")
+        }
+    }
+
+    private func fetchAllRecords(
+        matching query: CKQuery,
+        desiredKeys: [CKRecord.FieldKey]
+    ) async throws -> [CKRecord] {
+        var page = try await database.records(
+            matching: query,
+            desiredKeys: desiredKeys,
+            resultsLimit: CKQueryOperation.maximumResults
+        )
+        var records = successfulRecords(from: page.matchResults)
+
+        while let cursor = page.queryCursor {
+            page = try await database.records(
+                continuingMatchFrom: cursor,
+                desiredKeys: desiredKeys,
+                resultsLimit: CKQueryOperation.maximumResults
+            )
+            records.append(contentsOf: successfulRecords(from: page.matchResults))
+        }
+
+        return records
+    }
+
+    private func successfulRecords(
+        from results: [(CKRecord.ID, Result<CKRecord, Error>)]
+    ) -> [CKRecord] {
+        results.compactMap { _, result in
+            try? result.get()
+        }
+    }
+
+    @discardableResult
+    private func store(record: CKRecord) throws -> Bool {
+        guard let assetKey = record[CraftImageAssetKey.assetKeyField] as? String,
+              let asset = record[CraftImageAssetKey.fileField] as? CKAsset,
+              let sourceURL = asset.fileURL else {
+            return false
+        }
+
+        let data = try Data(contentsOf: sourceURL)
+        guard let image = UIImage(data: data) else {
+            throw CraftImageStoreError.invalidImageData
+        }
+
+        try data.write(to: cachedFileURL(for: assetKey), options: .atomic)
+        imageCache.setObject(image, forKey: assetKey as NSString)
+
+        let version = record[CraftImageAssetKey.versionField] as? Int64 ?? 1
+        defaults.set(Int(version), forKey: versionDefaultsKey(for: assetKey))
+        return true
+    }
+
+    private func cachedFileURL(for assetKey: String) -> URL {
+        cacheDirectory.appendingPathComponent(
+            CraftImageAssetKey.recordName(for: assetKey),
+            isDirectory: false
+        )
+    }
+
+    private func localVersion(for assetKey: String) -> Int64 {
+        Int64(defaults.integer(forKey: versionDefaultsKey(for: assetKey)))
+    }
+
+    private func versionDefaultsKey(for assetKey: String) -> String {
+        "craft-image.version.\(CraftImageAssetKey.recordName(for: assetKey))"
+    }
+
+    private func removeCachedRemoteImage(for assetKey: String) {
+        try? fileManager.removeItem(at: cachedFileURL(for: assetKey))
+        imageCache.removeObject(forKey: assetKey as NSString)
+        defaults.removeObject(forKey: versionDefaultsKey(for: assetKey))
+    }
+}
+
+private enum CraftImageStoreError: LocalizedError {
+    case invalidImageData
+
+    var errorDescription: String? {
+        "CloudKit returned an invalid image file."
+    }
+}
+
+@MainActor
+struct CraftImage: View {
+    @ObservedObject private var store: CraftImageStore
+    let key: String
+    let fallbackSystemName: String
+
+    init(
+        key: String,
+        fallbackSystemName: String = "photo",
+        store: CraftImageStore = .shared
+    ) {
+        self.key = key
+        self.fallbackSystemName = fallbackSystemName
+        _store = ObservedObject(wrappedValue: store)
+    }
+
+    var body: some View {
+        Group {
+            if let image = store.image(for: key) {
+                Image(uiImage: image)
+                    .resizable()
+                    .interpolation(.none)
+            } else {
+                Image(systemName: fallbackSystemName)
+                    .resizable()
+                    .symbolRenderingMode(.hierarchical)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .task(id: key) {
+            await store.load(key)
+        }
+    }
+}

--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -114,6 +114,7 @@ final class DataManager: ObservableObject {
             print("Loaded \(localRecipes.count) recipes from local cache.")
             self.recipes = localRecipes.sorted(by: { $0.name < $1.name })
             self.syncRecentSearches()
+            CraftImageStore.shared.prefetch(recipes: localRecipes)
         } else {
             print("No local cache found; will fetch from CloudKit on first view load.")
         }
@@ -318,6 +319,7 @@ final class DataManager: ObservableObject {
                 recipes = fetchedRecipes.sorted { $0.name < $1.name }
                 syncRecentSearches()
                 saveRecipesToLocalCache(fetchedRecipes)
+                CraftImageStore.shared.prefetch(recipes: fetchedRecipes)
                 lastUpdated = Date()
                 lastRecipeFetch = Date()
                 isLoading = false

--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -356,28 +356,13 @@ struct IngredientDetailPopup: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             VStack(spacing: 8) {
-                Group {
-                    if UIImage(named: detail) != nil {
-                        Image(detail)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: horizontalSizeClass == .regular ? 90 : 80, height: horizontalSizeClass == .regular ? 90 : 80)
-                            .padding(8)
-                            .background(Color(.systemGray5))
-                            .cornerRadius(12)
-                            .accessibilityLabel("Image of \(detail)")
-                    } else {
-                        Image(systemName: "photo")
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: horizontalSizeClass == .regular ? 90 : 80, height: horizontalSizeClass == .regular ? 90 : 80)
-                            .padding(8)
-                            .foregroundColor(.gray)
-                            .background(Color(.systemGray5))
-                            .cornerRadius(12)
-                            .accessibilityLabel("Image unavailable")
-                    }
-                }
+                CraftImage(key: detail)
+                    .scaledToFit()
+                    .frame(width: horizontalSizeClass == .regular ? 90 : 80, height: horizontalSizeClass == .regular ? 90 : 80)
+                    .padding(8)
+                    .background(Color(.systemGray5))
+                    .cornerRadius(12)
+                    .accessibilityLabel("Image of \(detail)")
                 Text(detail)
                     .font(.title2)
                     .fontWeight(.bold)
@@ -501,18 +486,9 @@ struct RemarkAndCategoryView: View {
                                     }
                                 }
                             )
-                        if UIImage(named: imageRemark) != nil {
-                            Image(imageRemark)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: horizontalSizeClass == .regular ? 28 : 24, height: horizontalSizeClass == .regular ? 28 : 24)
-                        } else {
-                            Image(systemName: "photo")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: horizontalSizeClass == .regular ? 28 : 24, height: horizontalSizeClass == .regular ? 28 : 24)
-                                .foregroundColor(.gray)
-                        }
+                        CraftImage(key: imageRemark)
+                            .scaledToFit()
+                            .frame(width: horizontalSizeClass == .regular ? 28 : 24, height: horizontalSizeClass == .regular ? 28 : 24)
                     }
                     .scaleEffect(animateRemark ? 1.15 : 1.0)
                     .accessibilityLabel("Remark image")
@@ -613,18 +589,9 @@ struct GridView: View {
                                 : nil
                             )
 
-                        if UIImage(named: recipe.image) != nil {
-                            Image(recipe.image)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: horizontalSizeClass == .regular ? 70 : 60, height: horizontalSizeClass == .regular ? 70 : 60)
-                        } else {
-                            Image(systemName: "photo")
-                                .resizable()
-                                .scaledToFit()
-                                .frame(width: horizontalSizeClass == .regular ? 70 : 60, height: horizontalSizeClass == .regular ? 70 : 60)
-                                .foregroundColor(.gray)
-                        }
+                        CraftImage(key: recipe.image)
+                            .scaledToFit()
+                            .frame(width: horizontalSizeClass == .regular ? 70 : 60, height: horizontalSizeClass == .regular ? 70 : 60)
                     }
                     .accessibilityLabel("Output: \(recipe.name)")
                     .accessibilityHint("Tap to view details")
@@ -765,18 +732,9 @@ struct GridCell: View {
                 )
 
             if !ingredient.isEmpty {
-                if UIImage(named: ingredient) != nil {
-                    Image(ingredient)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: cellSize - 10, height: cellSize - 10)
-                } else {
-                    Image(systemName: "photo")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: cellSize - 10, height: cellSize - 10)
-                        .foregroundColor(.gray)
-                }
+                CraftImage(key: ingredient)
+                    .scaledToFit()
+                    .frame(width: cellSize - 10, height: cellSize - 10)
             }
         }
         .accessibilityLabel(!ingredient.isEmpty ? "Ingredient: \(ingredient)" : "Empty slot")

--- a/Craftify/RecipeSearchView.swift
+++ b/Craftify/RecipeSearchView.swift
@@ -309,8 +309,7 @@ struct RecentSearchItem: View {
     
     var body: some View {
         HStack(spacing: 12) {
-            Image(recipe.image)
-                .resizable()
+            CraftImage(key: recipe.image)
                 .scaledToFit()
                 .frame(width: horizontalSizeClass == .regular ? 40 : 32, height: horizontalSizeClass == .regular ? 40 : 32)
                 .cornerRadius(6)

--- a/CraftifyTests/CraftifyTests.swift
+++ b/CraftifyTests/CraftifyTests.swift
@@ -138,3 +138,44 @@ extension CraftifyTests {
         #expect(decoded == chest)
     }
 }
+
+
+extension CraftifyTests {
+    @Test func imageAssetRecordNamesAreStableAndCloudKitSafe() {
+        #expect(
+            CraftImageAssetKey.recordName(for: "Oak Planks")
+                == "asset-T2FrIFBsYW5rcw"
+        )
+        #expect(
+            CraftImageAssetKey.recordName(for: "Oak Planks")
+                != CraftImageAssetKey.recordName(for: "Oak Log")
+        )
+    }
+
+    @MainActor
+    @Test func recipeImageKeysIncludeOutputsAlternatesAndRemarks() {
+        let recipe = Recipe(
+            id: 42,
+            name: "Test Recipe",
+            image: "Output",
+            ingredients: ["Ingredient", ""],
+            alternateIngredients: ["Alternate"],
+            alternateIngredients1: nil,
+            alternateIngredients2: nil,
+            alternateIngredients3: nil,
+            output: 1,
+            alternateOutput: nil,
+            alternateOutput1: nil,
+            alternateOutput2: nil,
+            alternateOutput3: nil,
+            category: "Test",
+            imageremark: "Crafting Table",
+            remarks: nil
+        )
+
+        #expect(
+            CraftImageStore.imageKeys(in: [recipe])
+                == ["Output", "Ingredient", "Alternate", "Crafting Table"]
+        )
+    }
+}


### PR DESCRIPTION
## What changed

- adds a shared CloudKit image store with memory and persistent disk caching
- keeps bundled asset-catalog images as the offline and migration fallback
- checks CloudKit asset versions every 15 minutes and downloads only missing or outdated files
- removes stale remote files when their CloudKit record is deleted
- resolves shared images in recipe rows, search, chests, detail output, ingredients, alternates, and remark images
- prefetches unique image keys from both locally cached and freshly fetched recipes
- adds tests for record-name compatibility and complete recipe-key collection

## Why

The app currently interprets recipe image strings only as bundled asset names. A recipe added after release therefore shows placeholders when its artwork was not compiled into that build. This change preserves the existing data model while allowing new artwork to arrive from CloudKit.

## Coordinated dependency

This PR pairs with [Craftify Manager PR #5](https://github.com/davevancauwenberghe/craftifymanager/pull/5). Deploy the additive `CraftImageAsset` production schema documented there before releasing this consumer update. Until the schema exists, the app continues using bundled images and placeholders.

## Validation

- verified every published branch file byte-for-byte against the reviewed source
- verified all dynamic recipe-image call sites now use the shared resolver
- added deterministic record-name and recipe-key unit coverage
- [Craftify iOS CI run #159](https://github.com/davevancauwenberghe/Craftify/actions/runs/30701474176) passed its build and test jobs
