### PR TITLE
Sync recipe images during manual refresh

### DIFF
--- a/Craftify/CraftImageStore.swift
+++ b/Craftify/CraftImageStore.swift
@@ -87,6 +87,10 @@ final class CraftImageStore: ObservableObject {
         await synchronize(keys: [assetKey])
     }
 
+    func refresh(recipes: [Recipe]) async {
+        await synchronize(keys: Self.imageKeys(in: recipes), force: true)
+    }
+
     static func imageKeys(in recipes: [Recipe]) -> Set<String> {
         var keys: Set<String> = []
 
@@ -118,13 +122,14 @@ final class CraftImageStore: ObservableObject {
         return keys
     }
 
-    private func synchronize(keys: Set<String>) async {
+    private func synchronize(keys: Set<String>, force: Bool = false) async {
         let usableKeys = Set(keys.filter {
             !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         })
         let now = Date()
         let dueKeys = usableKeys.filter { key in
             guard !loadingKeys.contains(key) else { return false }
+            if force { return true }
             guard let checked = lastChecked[key] else { return true }
             return now.timeIntervalSince(checked) >= refreshInterval
         }

--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -319,7 +319,11 @@ final class DataManager: ObservableObject {
                 recipes = fetchedRecipes.sorted { $0.name < $1.name }
                 syncRecentSearches()
                 saveRecipesToLocalCache(fetchedRecipes)
-                CraftImageStore.shared.prefetch(recipes: fetchedRecipes)
+                if isManual {
+                    await CraftImageStore.shared.refresh(recipes: fetchedRecipes)
+                } else {
+                    CraftImageStore.shared.prefetch(recipes: fetchedRecipes)
+                }
                 lastUpdated = Date()
                 lastRecipeFetch = Date()
                 isLoading = false

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -51,7 +51,7 @@ struct MoreView: View {
                 Section {
                     Button(action: syncRecipes) {
                         Label {
-                            Text(dataManager.isLoading ? "Syncing Recipes…" : "Sync Recipes")
+                            Text(dataManager.isLoading ? "Syncing Recipes & Images…" : "Sync Recipes & Images")
                                 .foregroundStyle(.primary)
                         } icon: {
                             if dataManager.isLoading {
@@ -74,7 +74,7 @@ struct MoreView: View {
                         Text("Sync is available again in \(remainingCooldownTime) second\(remainingCooldownTime == 1 ? "" : "s").")
                             .contentTransition(.numericText())
                     } else if !dataManager.isConnected {
-                        Text("Connect to the internet to sync recipes. Craftify will keep your existing recipes available offline.")
+                        Text("Connect to the internet to sync recipes and images. Craftify will keep your existing data available offline.")
                     }
                 }
             }
@@ -101,7 +101,7 @@ struct MoreView: View {
     private var syncHint: String {
         if !dataManager.isConnected { return "Unavailable while offline" }
         if remainingCooldownTime > 0 { return "Available in \(remainingCooldownTime) seconds" }
-        return "Fetch the latest Minecraft recipes"
+        return "Fetch the latest Minecraft recipes and images"
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- Rename the More screen action to **Sync Recipes & Images**
- Force a CloudKit image metadata/version review during manual recipe sync
- Await missing or updated image downloads before the manual sync finishes
- Keep the existing 15-minute throttle for automatic/background image checks

## Why
A manual sync should pick up an image that was added or replaced under an existing asset key without requiring the app to be terminated and relaunched.

## Validation
- Branch is based directly on the current `main`
- Normal prefetch behavior remains unchanged for startup and automatic recipe loads
- GitHub Actions should perform the project build/test validation

## Manual test
1. Add or replace a `CraftImageAsset` in CloudKit
2. Open More and tap **Sync Recipes & Images**
3. Confirm the new image appears without restarting Craftify