### PR TITLE
Persist recipe images and clear all downloaded data

### DIFF
--- a/Craftify/CraftImageStore.swift
+++ b/Craftify/CraftImageStore.swift
@@ -33,30 +33,40 @@ final class CraftImageStore: ObservableObject {
     private let database: CKDatabase
     private let fileManager: FileManager
     private let defaults: UserDefaults
-    private let cacheDirectory: URL
+    private let imageDirectory: URL
+    private let legacyCacheDirectory: URL
     private let imageCache = NSCache<NSString, UIImage>()
     private var loadingKeys: Set<String> = []
     private var lastChecked: [String: Date] = [:]
+    private var storageGeneration = 0
 
+    private static let versionDefaultsPrefix = "craft-image.version."
     private let queryBatchSize = 100
     private let refreshInterval: TimeInterval = 15 * 60
 
     init(
         containerIdentifier: String = "iCloud.craftifydb",
         fileManager: FileManager = .default,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        storageDirectory: URL? = nil,
+        legacyCacheDirectory: URL? = nil
     ) {
         self.database = CKContainer(identifier: containerIdentifier).publicCloudDatabase
         self.fileManager = fileManager
         self.defaults = defaults
 
-        let root = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
-        self.cacheDirectory = root.appendingPathComponent("CraftImageAssets", isDirectory: true)
-        try? fileManager.createDirectory(
-            at: cacheDirectory,
-            withIntermediateDirectories: true
-        )
+        let applicationSupportRoot = fileManager.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        )[0]
+        self.imageDirectory = storageDirectory ?? applicationSupportRoot
+            .appendingPathComponent("CraftImageAssets", isDirectory: true)
 
+        let cachesRoot = fileManager.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+        self.legacyCacheDirectory = legacyCacheDirectory ?? cachesRoot
+            .appendingPathComponent("CraftImageAssets", isDirectory: true)
+
+        prepareStorage()
         imageCache.countLimit = 300
     }
 
@@ -123,6 +133,7 @@ final class CraftImageStore: ObservableObject {
     }
 
     private func synchronize(keys: Set<String>, force: Bool = false) async {
+        let generation = storageGeneration
         let usableKeys = Set(keys.filter {
             !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         })
@@ -142,13 +153,15 @@ final class CraftImageStore: ObservableObject {
 
         let sortedKeys = requestedKeys.sorted()
         for start in stride(from: 0, to: sortedKeys.count, by: queryBatchSize) {
+            guard generation == storageGeneration else { return }
             let end = min(start + queryBatchSize, sortedKeys.count)
             let batch = Array(sortedKeys[start..<end])
-            await synchronize(batch: batch)
+            await synchronize(batch: batch, generation: generation)
         }
     }
 
-    private func synchronize(batch: [String]) async {
+    private func synchronize(batch: [String], generation: Int) async {
+        guard generation == storageGeneration else { return }
         let predicate = NSPredicate(
             format: "%K IN %@",
             CraftImageAssetKey.assetKeyField,
@@ -167,6 +180,7 @@ final class CraftImageStore: ObservableObject {
                     CraftImageAssetKey.versionField
                 ]
             )
+            guard generation == storageGeneration else { return }
 
             let metadata = metadataRecords.reduce(into: [String: Int64]()) { result, record in
                 guard let key = record[CraftImageAssetKey.assetKeyField] as? String else {
@@ -207,6 +221,7 @@ final class CraftImageStore: ObservableObject {
                         CraftImageAssetKey.versionField
                     ]
                 )
+                guard generation == storageGeneration else { return }
 
                 for record in assetRecords {
                     if try store(record: record) {
@@ -281,7 +296,7 @@ final class CraftImageStore: ObservableObject {
     }
 
     private func cachedFileURL(for assetKey: String) -> URL {
-        cacheDirectory.appendingPathComponent(
+        imageDirectory.appendingPathComponent(
             CraftImageAssetKey.recordName(for: assetKey),
             isDirectory: false
         )
@@ -292,7 +307,96 @@ final class CraftImageStore: ObservableObject {
     }
 
     private func versionDefaultsKey(for assetKey: String) -> String {
-        "craft-image.version.\(CraftImageAssetKey.recordName(for: assetKey))"
+        Self.versionDefaultsPrefix + CraftImageAssetKey.recordName(for: assetKey)
+    }
+
+    func clearDownloadedImages() throws {
+        storageGeneration += 1
+        loadingKeys.removeAll()
+        lastChecked.removeAll()
+        imageCache.removeAllObjects()
+
+        defaults.dictionaryRepresentation().keys
+            .filter { $0.hasPrefix(Self.versionDefaultsPrefix) }
+            .forEach { defaults.removeObject(forKey: $0) }
+
+        objectWillChange.send()
+        defer { try? createImageDirectory() }
+
+        if fileManager.fileExists(atPath: imageDirectory.path) {
+            try fileManager.removeItem(at: imageDirectory)
+        }
+        if legacyCacheDirectory != imageDirectory,
+           fileManager.fileExists(atPath: legacyCacheDirectory.path) {
+            try fileManager.removeItem(at: legacyCacheDirectory)
+        }
+
+        try createImageDirectory()
+        objectWillChange.send()
+    }
+
+    private func prepareStorage() {
+        do {
+            try createImageDirectory()
+            migrateLegacyImagesIfNeeded()
+        } catch {
+            print("Unable to prepare persistent image storage: \(error.localizedDescription)")
+        }
+    }
+
+    private func createImageDirectory() throws {
+        try fileManager.createDirectory(
+            at: imageDirectory,
+            withIntermediateDirectories: true
+        )
+
+        var directoryURL = imageDirectory
+        var resourceValues = URLResourceValues()
+        resourceValues.isExcludedFromBackup = true
+        do {
+            try directoryURL.setResourceValues(resourceValues)
+        } catch {
+            print("Unable to exclude downloaded images from backup: \(error.localizedDescription)")
+        }
+    }
+
+    private func migrateLegacyImagesIfNeeded() {
+        guard legacyCacheDirectory != imageDirectory,
+              fileManager.fileExists(atPath: legacyCacheDirectory.path),
+              let legacyFiles = try? fileManager.contentsOfDirectory(
+                at: legacyCacheDirectory,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+              ) else {
+            return
+        }
+
+        for sourceURL in legacyFiles {
+            let destinationURL = imageDirectory.appendingPathComponent(
+                sourceURL.lastPathComponent,
+                isDirectory: false
+            )
+
+            do {
+                if fileManager.fileExists(atPath: destinationURL.path) {
+                    try fileManager.removeItem(at: sourceURL)
+                } else {
+                    try fileManager.moveItem(at: sourceURL, to: destinationURL)
+                }
+            } catch {
+                print(
+                    "Unable to migrate downloaded image \(sourceURL.lastPathComponent): "
+                    + error.localizedDescription
+                )
+            }
+        }
+
+        if let remainingFiles = try? fileManager.contentsOfDirectory(
+            at: legacyCacheDirectory,
+            includingPropertiesForKeys: nil
+        ), remainingFiles.isEmpty {
+            try? fileManager.removeItem(at: legacyCacheDirectory)
+        }
     }
 
     private func removeCachedRemoteImage(for assetKey: String) {

--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -49,6 +49,7 @@ final class DataManager: ObservableObject {
     private let networkMonitor = NWPathMonitor()
     private let networkQueue = DispatchQueue(label: "NetworkMonitor")
     private let keyValueStore: any KeyValueStore
+    private let imageStore: CraftImageStore
 
     enum ErrorType: String {
         case network = "Network issue, please try again later."
@@ -59,8 +60,12 @@ final class DataManager: ObservableObject {
         case unknown = "An unexpected error occurred. Please try again later."
     }
 
-    init(keyValueStore: any KeyValueStore = NSUbiquitousKeyValueStore.default) {
+    init(
+        keyValueStore: any KeyValueStore = NSUbiquitousKeyValueStore.default,
+        imageStore: CraftImageStore = .shared
+    ) {
         self.keyValueStore = keyValueStore
+        self.imageStore = imageStore
         keyValueStore.synchronize()
 
         networkMonitor.pathUpdateHandler = { [weak self] path in
@@ -114,7 +119,7 @@ final class DataManager: ObservableObject {
             print("Loaded \(localRecipes.count) recipes from local cache.")
             self.recipes = localRecipes.sorted(by: { $0.name < $1.name })
             self.syncRecentSearches()
-            CraftImageStore.shared.prefetch(recipes: localRecipes)
+            imageStore.prefetch(recipes: localRecipes)
         } else {
             print("No local cache found; will fetch from CloudKit on first view load.")
         }
@@ -320,9 +325,9 @@ final class DataManager: ObservableObject {
                 syncRecentSearches()
                 saveRecipesToLocalCache(fetchedRecipes)
                 if isManual {
-                    await CraftImageStore.shared.refresh(recipes: fetchedRecipes)
+                    await imageStore.refresh(recipes: fetchedRecipes)
                 } else {
-                    CraftImageStore.shared.prefetch(recipes: fetchedRecipes)
+                    imageStore.prefetch(recipes: fetchedRecipes)
                 }
                 lastUpdated = Date()
                 lastRecipeFetch = Date()
@@ -515,12 +520,7 @@ final class DataManager: ObservableObject {
         Task {
             do {
                 let database = CKContainer(identifier: "iCloud.craftifydb").publicCloudDatabase
-                let (_, deleteResults) = try await database.modifyRecords(saving: [], deleting: recordIDs)
-                for result in deleteResults.values {
-                    if case .failure(let error) = result {
-                        throw error
-                    }
-                }
+                try await deleteRecipeReportRecords(recordIDs, from: database)
                 accessibilityAnnouncement = "All reports deleted successfully"
                 completion(true)
             } catch {
@@ -534,15 +534,23 @@ final class DataManager: ObservableObject {
 
     func clearCache(completion: @escaping (Bool) -> Void) {
         let fileURL = getCacheDirectory().appendingPathComponent(localCacheFileName())
+
         do {
-            try FileManager.default.removeItem(at: fileURL)
+            if FileManager.default.fileExists(atPath: fileURL.path) {
+                try FileManager.default.removeItem(at: fileURL)
+            }
+            try imageStore.clearDownloadedImages()
+
             recipes = []
-            cacheClearedMessage = "Cache cleared successfully."
-            accessibilityAnnouncement = "Cache cleared successfully."
+            lastRecipeFetch = nil
+            lastUpdated = nil
+            cacheClearedMessage = "Recipe and image data cleared successfully."
+            accessibilityAnnouncement = cacheClearedMessage
             completion(true)
         } catch {
+            errorMessage = "Failed to clear local recipe and image data: \(error.localizedDescription)"
             cacheClearedMessage = "Failed to clear cache."
-            accessibilityAnnouncement = "Failed to clear cache."
+            accessibilityAnnouncement = errorMessage
             completion(false)
         }
     }
@@ -551,15 +559,67 @@ final class DataManager: ObservableObject {
         clearCache { cacheSuccess in
             self.clearChestsAndLegacyFavorites()
             self.clearRecentSearches()
+            self.lastReportStatusFetchTime = nil
 
-            if cacheSuccess {
-                self.cacheClearedMessage = "All data cleared successfully."
-                self.accessibilityAnnouncement = "All data cleared successfully."
-                completion(true)
-            } else {
-                self.cacheClearedMessage = "Failed to clear all data."
-                self.accessibilityAnnouncement = "Failed to clear all data."
+            guard self.isConnected else {
+                self.errorMessage = ErrorType.network.rawValue
+                self.cacheClearedMessage = "Local data cleared, but recipe reports could not be deleted while offline."
+                self.accessibilityAnnouncement = self.cacheClearedMessage
                 completion(false)
+                return
+            }
+
+            Task {
+                do {
+                    try await self.deleteAllCurrentUserRecipeReports()
+                    if cacheSuccess {
+                        self.cacheClearedMessage = "All data cleared successfully."
+                        self.accessibilityAnnouncement = "All data cleared successfully."
+                        completion(true)
+                    } else {
+                        self.cacheClearedMessage = "Recipe reports were deleted, but some local data could not be cleared."
+                        self.accessibilityAnnouncement = self.cacheClearedMessage
+                        completion(false)
+                    }
+                } catch {
+                    let type = self.errorType(for: error)
+                    self.errorMessage = "Local data was cleared, but recipe reports could not be deleted: \(type.rawValue)"
+                    self.cacheClearedMessage = "Failed to clear all data."
+                    self.accessibilityAnnouncement = self.errorMessage
+                    completion(false)
+                }
+            }
+        }
+    }
+
+    private func deleteAllCurrentUserRecipeReports() async throws {
+        let container = CKContainer(identifier: "iCloud.craftifydb")
+        let userRecordID = try await container.userRecordID()
+        let userReference = CKRecord.Reference(recordID: userRecordID, action: .none)
+        let predicate = NSPredicate(format: "___createdBy == %@", userReference)
+        let query = CKQuery(recordType: "PublicRecipeReport", predicate: predicate)
+        let database = container.publicCloudDatabase
+        let records = try await fetchAllRecords(matching: query, from: database)
+        try await deleteRecipeReportRecords(records.map(\.recordID), from: database)
+    }
+
+    private func deleteRecipeReportRecords(
+        _ recordIDs: [CKRecord.ID],
+        from database: CKDatabase
+    ) async throws {
+        let batchSize = 200
+        for start in stride(from: 0, to: recordIDs.count, by: batchSize) {
+            let end = min(start + batchSize, recordIDs.count)
+            let batch = Array(recordIDs[start..<end])
+            let (_, deleteResults) = try await database.modifyRecords(
+                saving: [],
+                deleting: batch
+            )
+
+            for result in deleteResults.values {
+                if case .failure(let error) = result {
+                    throw error
+                }
             }
         }
     }

--- a/Craftify/SupportView.swift
+++ b/Craftify/SupportView.swift
@@ -52,9 +52,9 @@ struct SupportView: View {
                         trailing: horizontalSizeClass == .regular ? 16 : 12
                     ))
                     .accessibilityLabel("Clear All Data")
-                    .accessibilityHint("Clears all local and iCloud data, including chests, recent searches, and recipe reports")
+                    .accessibilityHint("Clears local recipe data, downloaded images, chests, recent searches, and recipe reports")
 
-                    Text("This will permanently delete all your chests, recent searches (stored in iCloud), recipe reports (stored in CloudKit), and the local recipe cache.")
+                    Text("This will permanently delete your chests, recent searches, CloudKit recipe reports, local recipe data, and downloaded recipe images.")
                         .font(horizontalSizeClass == .regular ? .body : .subheadline)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.leading)
@@ -62,7 +62,7 @@ struct SupportView: View {
                         .padding(.horizontal, horizontalSizeClass == .regular ? 12 : 8)
                         .padding(.vertical, horizontalSizeClass == .regular ? 8 : 4)
                         .accessibilityLabel("Clear All Data Note")
-                        .accessibilityHint("This will permanently delete all your chests, recent searches, recipe reports, and the local recipe cache.")
+                        .accessibilityHint("This will permanently delete your chests, recent searches, recipe reports, local recipe data, and downloaded recipe images.")
 
                     Button(action: {
                         dataManager.clearCache { success in
@@ -85,9 +85,9 @@ struct SupportView: View {
                         trailing: horizontalSizeClass == .regular ? 16 : 12
                     ))
                     .accessibilityLabel("Clear Cache")
-                    .accessibilityHint("Clears the cached Minecraft recipes, keeping iCloud data like chests")
+                    .accessibilityHint("Clears local Minecraft recipes and downloaded images, keeping iCloud data like chests")
 
-                    Text("This will permanently delete the local recipe cache, keeping iCloud data like chests and recent searches.")
+                    Text("This will permanently delete local recipe data and downloaded recipe images, keeping iCloud data like chests and recent searches.")
                         .font(horizontalSizeClass == .regular ? .body : .subheadline)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.leading)
@@ -95,7 +95,7 @@ struct SupportView: View {
                         .padding(.horizontal, horizontalSizeClass == .regular ? 12 : 8)
                         .padding(.vertical, horizontalSizeClass == .regular ? 8 : 4)
                         .accessibilityLabel("Clear Cache Note")
-                        .accessibilityHint("This will permanently delete the local recipe cache, keeping iCloud data like chests and recent searches.")
+                        .accessibilityHint("This will permanently delete local recipe data and downloaded recipe images, keeping iCloud data like chests and recent searches.")
                 }
 
                 Section(header: Text("Privacy").font(.headline).minimumScaleFactor(0.6)) {
@@ -138,7 +138,7 @@ struct SupportView: View {
             .alert(isPresented: $showClearDataAlert) {
                 Alert(
                     title: Text("Clear All Data"),
-                    message: Text("Are you sure? This will remove all your chests, recent searches, recipe reports, and the local recipe cache. This action cannot be undone."),
+                    message: Text("Are you sure? This will remove your chests, recent searches, CloudKit recipe reports, local recipe data, and downloaded recipe images. This action cannot be undone."),
                     primaryButton: .destructive(Text("Clear All Data")) {
                         dataManager.clearAllData { success in
                             if success {
@@ -183,7 +183,7 @@ struct PrivacyPolicyContent: View {
                 .minimumScaleFactor(0.6)
                 .accessibilityAddTraits(.isHeader)
 
-            Text("Last updated: 30 July 2026")
+            Text("Last updated: 1 August 2026")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
                 .minimumScaleFactor(0.6)
@@ -210,7 +210,7 @@ struct PrivacyPolicyContent: View {
                             Text("• Legacy Favorites: If you used Favorites in an earlier version, its recipe IDs may remain in iCloud. Craftify no longer reads or imports them, and \"Clear All Data\" removes them.")
                             Text("• Recent Searches: Recipe names when you search for recipes, stored in iCloud to sync across your devices.")
                             Text("• Recipe Reports (Optional): When you report an issue, you may submit a recipe name, category, and description. These are stored in a private CloudKit database (accessible only to you) for the \"My Reports\" feature, allowing you to view and manage your reports across devices.")
-                            Text("• Local Recipe Cache: Recipes are cached on your device for offline access but contain no personal data.")
+                            Text("• Local Recipe and Image Data: Recipes and downloaded CloudKit images are stored on your device for reliable offline access but contain no personal data.")
                         }
                         .font(.body)
                         .minimumScaleFactor(0.6)
@@ -251,7 +251,7 @@ struct PrivacyPolicyContent: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("• Chests, Legacy Favorites, and Recent Searches: Chest names, sizes, ordering, recipe IDs (including Favorites saved by earlier versions), and recent recipe names are stored in your iCloud account, protected by Apple’s encryption. We cannot access this data.")
                             Text("• Recipe Reports: Stored privately in a CloudKit database (accessible only to you via your iCloud account) for the \"My Reports\" feature.")
-                            Text("• Local Recipe Cache: Stored on your device with no personal information.")
+                            Text("• Local Recipe and Image Data: Stored persistently on your device, excluded from device backups, and contains no personal information.")
                         }
                         .font(.body)
                         .minimumScaleFactor(0.6)
@@ -304,8 +304,8 @@ struct PrivacyPolicyContent: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("• Chests: Swipe a chest or a stored recipe to delete it. Use Edit to rearrange chests.")
                             Text("• Recent Searches: Tap \"Clear All\" in the Search tab to remove all recent searches.")
-                            Text("• Clear All Data: Tap \"Clear All Data\" in this section to delete everything, including Chests, legacy Favorites, Recent Searches, Recipe Reports, and the local cache.")
-                            Text("• Clear Cache: Use \"Clear Cache\" in this section to remove the local cache, keeping iCloud data like Chests.")
+                            Text("• Clear All Data: Tap \"Clear All Data\" in this section to delete Chests, legacy Favorites, Recent Searches, CloudKit Recipe Reports, local recipe data, and downloaded images.")
+                            Text("• Clear Cache: Use \"Clear Cache\" in this section to remove local recipe data and downloaded images while keeping iCloud data like Chests.")
                             Text("• Recipe Reports: In the \"My Reports\" section of \"Report Issue\", you can view and delete your reports, which also removes them from CloudKit.")
                         }
                         .font(.body)

--- a/CraftifyTests/CraftifyTests.swift
+++ b/CraftifyTests/CraftifyTests.swift
@@ -179,3 +179,60 @@ extension CraftifyTests {
         )
     }
 }
+
+
+extension CraftifyTests {
+    @MainActor
+    @Test func downloadedImagesMigrateToPersistentStorageAndClearCompletely() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        let persistentDirectory = root.appendingPathComponent(
+            "ApplicationSupportImages",
+            isDirectory: true
+        )
+        let legacyDirectory = root.appendingPathComponent(
+            "LegacyCacheImages",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(
+            at: legacyDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? fileManager.removeItem(at: root) }
+
+        let assetKey = "Blue Candle"
+        let fileName = CraftImageAssetKey.recordName(for: assetKey)
+        let legacyFile = legacyDirectory.appendingPathComponent(fileName)
+        try Data("image-data".utf8).write(to: legacyFile)
+
+        let suiteName = "CraftImageStoreTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let versionKey = "craft-image.version.\(fileName)"
+        defaults.set(4, forKey: versionKey)
+
+        let imageStore = CraftImageStore(
+            fileManager: fileManager,
+            defaults: defaults,
+            storageDirectory: persistentDirectory,
+            legacyCacheDirectory: legacyDirectory
+        )
+        let migratedFile = persistentDirectory.appendingPathComponent(fileName)
+
+        #expect(fileManager.fileExists(atPath: migratedFile.path))
+        #expect(!fileManager.fileExists(atPath: legacyFile.path))
+
+        try imageStore.clearDownloadedImages()
+
+        let remainingFiles = try fileManager.contentsOfDirectory(
+            at: persistentDirectory,
+            includingPropertiesForKeys: nil
+        )
+        #expect(remainingFiles.isEmpty)
+        #expect(defaults.object(forKey: versionKey) == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- Move CloudKit recipe images from the purgeable Caches directory to Application Support
- Exclude downloaded images from device backups because CloudKit remains the source of truth
- Migrate previously downloaded images on first launch without requiring another download
- Make Clear Cache and Clear All Data remove downloaded files, decoded images, image versions, and refresh state
- Invalidate in-flight image sync work so cleared files cannot reappear after deletion
- Make Clear All Data query and delete every PublicRecipeReport created by the signed-in user
- Update Support & Privacy descriptions to match the implemented behavior
- Add coverage for legacy image migration and complete image-state clearing

## Why
Recipe and ingredient images are essential offline content. Files in Library/Caches may be purged by iOS, whereas Application Support is app-managed persistent storage. Clear Cache and Clear All Data also need to explicitly remove the new persistent image library and its associated state.

The existing Clear All Data implementation claimed to delete CloudKit recipe reports but never invoked report deletion.

## Compatibility
- No CloudKit schema change is required
- Existing cached images are migrated automatically
- Bundled image assets remain untouched as fallbacks
- Removing the app still removes its Application Support files

## Validation
- Added a test that seeds the legacy cache, verifies migration, clears the library, and verifies files and version metadata are removed
- GitHub Actions should perform the complete iOS build and test suite

## Manual test
1. Launch an updating build with previously cached CloudKit images and verify they remain available offline
2. Use Clear Cache and confirm recipes and downloaded images are removed while chest/iCloud data remains
3. Sync again and confirm images download normally
4. Submit a recipe report, use Clear All Data, and confirm the report no longer appears in My Reports