### PR TITLE
Prevent cleared recipe data from being recreated

### DIFF
--- a/Craftify/CraftImageStore.swift
+++ b/Craftify/CraftImageStore.swift
@@ -86,19 +86,26 @@ final class CraftImageStore: ObservableObject {
 
     func prefetch(recipes: [Recipe]) {
         let keys = Self.imageKeys(in: recipes)
+        let generation = storageGeneration
         Task { [weak self] in
-            await self?.synchronize(keys: keys)
+            await self?.synchronize(keys: keys, generation: generation)
         }
     }
 
     func load(_ assetKey: String) async {
         let trimmed = assetKey.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        await synchronize(keys: [assetKey])
+        let generation = storageGeneration
+        await synchronize(keys: [assetKey], generation: generation)
     }
 
     func refresh(recipes: [Recipe]) async {
-        await synchronize(keys: Self.imageKeys(in: recipes), force: true)
+        let generation = storageGeneration
+        await synchronize(
+            keys: Self.imageKeys(in: recipes),
+            force: true,
+            generation: generation
+        )
     }
 
     static func imageKeys(in recipes: [Recipe]) -> Set<String> {
@@ -132,8 +139,13 @@ final class CraftImageStore: ObservableObject {
         return keys
     }
 
-    private func synchronize(keys: Set<String>, force: Bool = false) async {
-        let generation = storageGeneration
+    private func synchronize(
+        keys: Set<String>,
+        force: Bool = false,
+        generation: Int
+    ) async {
+        guard generation == storageGeneration else { return }
+
         let usableKeys = Set(keys.filter {
             !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         })
@@ -237,6 +249,8 @@ final class CraftImageStore: ObservableObject {
                 objectWillChange.send()
             }
         } catch {
+            guard generation == storageGeneration else { return }
+
             let checkedAt = Date()
             batch.forEach { lastChecked[$0] = checkedAt }
             print("Craft image sync failed: \(error.localizedDescription)")

--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -50,6 +50,7 @@ final class DataManager: ObservableObject {
     private let networkQueue = DispatchQueue(label: "NetworkMonitor")
     private let keyValueStore: any KeyValueStore
     private let imageStore: CraftImageStore
+    private var recipeFetchGeneration = 0
 
     enum ErrorType: String {
         case network = "Network issue, please try again later."
@@ -297,8 +298,9 @@ final class DataManager: ObservableObject {
     }
 
     func loadData(isManual: Bool = false, completion: @escaping () -> Void) {
+        let generation = recipeFetchGeneration
         Task {
-            await loadData(isManual: isManual)
+            await loadData(isManual: isManual, generation: generation)
             completion()
         }
     }
@@ -309,7 +311,9 @@ final class DataManager: ObservableObject {
         }
     }
 
-    private func loadData(isManual: Bool) async {
+    private func loadData(isManual: Bool, generation: Int) async {
+        guard generation == recipeFetchGeneration else { return }
+
         isLoading = true
         if isManual { isManualSyncing = true }
         errorMessage = nil
@@ -318,14 +322,19 @@ final class DataManager: ObservableObject {
         let query = CKQuery(recordType: "Recipe", predicate: NSPredicate(value: true))
 
         for retryCount in 0...3 {
+            guard generation == recipeFetchGeneration else { return }
+
             do {
                 let records = try await fetchAllRecords(matching: query, from: database)
+                guard generation == recipeFetchGeneration else { return }
+
                 let fetchedRecipes = records.compactMap(convertRecordToRecipe)
                 recipes = fetchedRecipes.sorted { $0.name < $1.name }
                 syncRecentSearches()
                 saveRecipesToLocalCache(fetchedRecipes)
                 if isManual {
                     await imageStore.refresh(recipes: fetchedRecipes)
+                    guard generation == recipeFetchGeneration else { return }
                 } else {
                     imageStore.prefetch(recipes: fetchedRecipes)
                 }
@@ -335,8 +344,11 @@ final class DataManager: ObservableObject {
                 isManualSyncing = false
                 return
             } catch {
+                guard generation == recipeFetchGeneration else { return }
+
                 if let ckError = error as? CKError, ckError.isRetryable, retryCount < 3 {
                     try? await Task.sleep(for: .seconds(3))
+                    guard generation == recipeFetchGeneration else { return }
                     continue
                 }
                 let type = errorType(for: error)
@@ -533,6 +545,10 @@ final class DataManager: ObservableObject {
     }
 
     func clearCache(completion: @escaping (Bool) -> Void) {
+        recipeFetchGeneration += 1
+        isLoading = false
+        isManualSyncing = false
+
         let fileURL = getCacheDirectory().appendingPathComponent(localCacheFileName())
 
         do {

--- a/Craftify/SupportView.swift
+++ b/Craftify/SupportView.swift
@@ -183,7 +183,7 @@ struct PrivacyPolicyContent: View {
                 .minimumScaleFactor(0.6)
                 .accessibilityAddTraits(.isHeader)
 
-            Text("Last updated: 1 August 2026")
+            Text("Last updated: 2 August 2026")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
                 .minimumScaleFactor(0.6)
@@ -251,7 +251,8 @@ struct PrivacyPolicyContent: View {
                         VStack(alignment: .leading, spacing: 4) {
                             Text("• Chests, Legacy Favorites, and Recent Searches: Chest names, sizes, ordering, recipe IDs (including Favorites saved by earlier versions), and recent recipe names are stored in your iCloud account, protected by Apple’s encryption. We cannot access this data.")
                             Text("• Recipe Reports: Stored privately in a CloudKit database (accessible only to you via your iCloud account) for the \"My Reports\" feature.")
-                            Text("• Local Recipe and Image Data: Stored persistently on your device, excluded from device backups, and contains no personal information.")
+                            Text("• Local Recipe Data: Stored on your device and contains no personal information.")
+                            Text("• Downloaded Recipe Images: Stored persistently on your device, excluded from device backups, and contain no personal information.")
                         }
                         .font(.body)
                         .minimumScaleFactor(0.6)


### PR DESCRIPTION
## Summary
- Capture a recipe-fetch generation before asynchronous work is scheduled
- Invalidate pending recipe fetches before Clear Cache removes local data
- Guard recipe responses, retries, and manual image refresh completion against stale generations
- Capture image-storage generations before prefetch tasks are scheduled
- Prevent failed stale image requests from restoring the 15-minute last-checked state
- Split the Support privacy description so only downloaded images are described as excluded from backups

## Review feedback addressed
This is a follow-up to merged PR #62 and implements all three findings from the Codex review:

1. A pending recipe fetch can no longer recreate recipes.json or trigger image downloads after a clear
2. A stale failed image sync can no longer repopulate lastChecked after image state is cleared
3. The backup wording now accurately distinguishes recipe data from downloaded images

## Additional safety
Clear Cache immediately resets recipe loading indicators when it invalidates pending fetches. Image prefetch captures its generation before creating the Task, which also covers work that was queued but had not started when the clear occurred.

## Validation
GitHub Actions should run the complete Craftify iOS build and test suite.

## Manual test
1. Start Sync Recipes & Images and immediately use Clear Cache
2. Wait for the original CloudKit request to finish
3. Confirm recipes.json and downloaded images remain cleared
4. Sync again and confirm recipes and images download immediately without a 15-minute delay