### PR TITLE
Show recipe and image progress during onboarding

### DIFF
--- a/Craftify/CraftImageStore.swift
+++ b/Craftify/CraftImageStore.swift
@@ -111,11 +111,13 @@ final class CraftImageStore: ObservableObject {
     func prepare(
         recipes: [Recipe],
         progress: @escaping (Int, Int) -> Void
-    ) async {
+    ) async -> Bool {
         let generation = storageGeneration
-        await synchronize(
+        return await synchronize(
             keys: Self.imageKeys(in: recipes),
+            force: true,
             generation: generation,
+            stopOnFailure: true,
             progress: progress
         )
     }
@@ -151,13 +153,15 @@ final class CraftImageStore: ObservableObject {
         return keys
     }
 
+    @discardableResult
     private func synchronize(
         keys: Set<String>,
         force: Bool = false,
         generation: Int,
+        stopOnFailure: Bool = false,
         progress: ((Int, Int) -> Void)? = nil
-    ) async {
-        guard generation == storageGeneration else { return }
+    ) async -> Bool {
+        guard generation == storageGeneration else { return false }
 
         let usableKeys = Set(keys.filter {
             !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -174,26 +178,37 @@ final class CraftImageStore: ObservableObject {
         var prepared = total - dueKeys.count
         progress?(prepared, total)
 
-        guard !dueKeys.isEmpty else { return }
+        guard !dueKeys.isEmpty else { return true }
 
         let requestedKeys = Set(dueKeys)
         loadingKeys.formUnion(requestedKeys)
         defer { loadingKeys.subtract(requestedKeys) }
 
+        var allSucceeded = true
         let sortedKeys = requestedKeys.sorted()
         for start in stride(from: 0, to: sortedKeys.count, by: queryBatchSize) {
-            guard generation == storageGeneration else { return }
+            guard generation == storageGeneration else { return false }
             let end = min(start + queryBatchSize, sortedKeys.count)
             let batch = Array(sortedKeys[start..<end])
-            await synchronize(batch: batch, generation: generation)
-            guard generation == storageGeneration else { return }
-            prepared += batch.count
-            progress?(prepared, total)
+            let batchSucceeded = await synchronize(
+                batch: batch,
+                generation: generation
+            )
+            guard generation == storageGeneration else { return false }
+
+            if !batchSucceeded {
+                allSucceeded = false
+                if stopOnFailure { return false }
+            } else {
+                prepared += batch.count
+                progress?(prepared, total)
+            }
         }
+        return allSucceeded
     }
 
-    private func synchronize(batch: [String], generation: Int) async {
-        guard generation == storageGeneration else { return }
+    private func synchronize(batch: [String], generation: Int) async -> Bool {
+        guard generation == storageGeneration else { return false }
         let predicate = NSPredicate(
             format: "%K IN %@",
             CraftImageAssetKey.assetKeyField,
@@ -212,7 +227,7 @@ final class CraftImageStore: ObservableObject {
                     CraftImageAssetKey.versionField
                 ]
             )
-            guard generation == storageGeneration else { return }
+            guard generation == storageGeneration else { return false }
 
             let metadata = metadataRecords.reduce(into: [String: Int64]()) { result, record in
                 guard let key = record[CraftImageAssetKey.assetKeyField] as? String else {
@@ -253,7 +268,7 @@ final class CraftImageStore: ObservableObject {
                         CraftImageAssetKey.versionField
                     ]
                 )
-                guard generation == storageGeneration else { return }
+                guard generation == storageGeneration else { return false }
 
                 for record in assetRecords {
                     if try store(record: record) {
@@ -268,12 +283,14 @@ final class CraftImageStore: ObservableObject {
             if cacheChanged {
                 objectWillChange.send()
             }
+            return true
         } catch {
-            guard generation == storageGeneration else { return }
+            guard generation == storageGeneration else { return false }
 
             let checkedAt = Date()
             batch.forEach { lastChecked[$0] = checkedAt }
             print("Craft image sync failed: \(error.localizedDescription)")
+            return false
         }
     }
 
@@ -286,7 +303,7 @@ final class CraftImageStore: ObservableObject {
             desiredKeys: desiredKeys,
             resultsLimit: CKQueryOperation.maximumResults
         )
-        var records = successfulRecords(from: page.matchResults)
+        var records = try successfulRecords(from: page.matchResults)
 
         while let cursor = page.queryCursor {
             page = try await database.records(
@@ -294,7 +311,7 @@ final class CraftImageStore: ObservableObject {
                 desiredKeys: desiredKeys,
                 resultsLimit: CKQueryOperation.maximumResults
             )
-            records.append(contentsOf: successfulRecords(from: page.matchResults))
+            records.append(contentsOf: try successfulRecords(from: page.matchResults))
         }
 
         return records
@@ -302,9 +319,9 @@ final class CraftImageStore: ObservableObject {
 
     private func successfulRecords(
         from results: [(CKRecord.ID, Result<CKRecord, Error>)]
-    ) -> [CKRecord] {
-        results.compactMap { _, result in
-            try? result.get()
+    ) throws -> [CKRecord] {
+        try results.map { _, result in
+            try result.get()
         }
     }
 

--- a/Craftify/CraftImageStore.swift
+++ b/Craftify/CraftImageStore.swift
@@ -108,6 +108,18 @@ final class CraftImageStore: ObservableObject {
         )
     }
 
+    func prepare(
+        recipes: [Recipe],
+        progress: @escaping (Int, Int) -> Void
+    ) async {
+        let generation = storageGeneration
+        await synchronize(
+            keys: Self.imageKeys(in: recipes),
+            generation: generation,
+            progress: progress
+        )
+    }
+
     static func imageKeys(in recipes: [Recipe]) -> Set<String> {
         var keys: Set<String> = []
 
@@ -142,7 +154,8 @@ final class CraftImageStore: ObservableObject {
     private func synchronize(
         keys: Set<String>,
         force: Bool = false,
-        generation: Int
+        generation: Int,
+        progress: ((Int, Int) -> Void)? = nil
     ) async {
         guard generation == storageGeneration else { return }
 
@@ -157,6 +170,10 @@ final class CraftImageStore: ObservableObject {
             return now.timeIntervalSince(checked) >= refreshInterval
         }
 
+        let total = usableKeys.count
+        var prepared = total - dueKeys.count
+        progress?(prepared, total)
+
         guard !dueKeys.isEmpty else { return }
 
         let requestedKeys = Set(dueKeys)
@@ -169,6 +186,9 @@ final class CraftImageStore: ObservableObject {
             let end = min(start + queryBatchSize, sortedKeys.count)
             let batch = Array(sortedKeys[start..<end])
             await synchronize(batch: batch, generation: generation)
+            guard generation == storageGeneration else { return }
+            prepared += batch.count
+            progress?(prepared, total)
         }
     }
 

--- a/Craftify/CraftifyApp.swift
+++ b/Craftify/CraftifyApp.swift
@@ -51,7 +51,10 @@ struct CraftifyApp: App {
                             showOnboarding = false
                         },
                         onRetry: {
-                            dataManager.fetchRecipes(isManual: false)
+                            dataManager.fetchRecipes(
+                                isManual: false,
+                                waitForImages: !hasLaunchedBefore
+                            )
                         },
                         horizontalSizeClass: UIDevice.current.userInterfaceIdiom == .pad ? .regular : .compact
                     )
@@ -71,7 +74,10 @@ struct CraftifyApp: App {
             .accessibilityElement(children: .contain)
             .accessibilityLabel("Craftify App")
             .onAppear {
-                dataManager.fetchRecipes(isManual: false)
+                dataManager.fetchRecipes(
+                    isManual: false,
+                    waitForImages: !hasLaunchedBefore
+                )
                 if !hasLaunchedBefore {
                     dismissOnboardingAfterLoading = true
                     showOnboarding = true

--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -58,6 +58,7 @@ final class DataManager: ObservableObject {
     private let keyValueStore: any KeyValueStore
     private let imageStore: CraftImageStore
     private var recipeFetchGeneration = 0
+    private var shouldPersistRecipeBookLoadingError = false
 
     private static let catalogRecordName = "craftify-catalog-current"
     private static let catalogRecipeCountField = "recipeCount"
@@ -108,6 +109,9 @@ final class DataManager: ObservableObject {
             .sink { [weak self] message in
                 if message != nil {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                        guard self?.shouldPersistRecipeBookLoadingError != true else {
+                            return
+                        }
                         self?.errorMessage = nil
                     }
                 }
@@ -294,7 +298,10 @@ final class DataManager: ObservableObject {
         waitForImages: Bool = false,
         completion: @escaping () -> Void = {}
     ) {
+        shouldPersistRecipeBookLoadingError = false
+
         if !isConnected {
+            shouldPersistRecipeBookLoadingError = waitForImages
             errorMessage = "No internet connection. Try again later."
             accessibilityAnnouncement = errorMessage
             completion()
@@ -348,6 +355,7 @@ final class DataManager: ObservableObject {
 
         isLoading = true
         if isManual { isManualSyncing = true }
+        shouldPersistRecipeBookLoadingError = false
         errorMessage = nil
 
         let database = CKContainer(identifier: "iCloud.craftifydb").publicCloudDatabase
@@ -398,7 +406,9 @@ final class DataManager: ObservableObject {
                         prepared: 0,
                         total: imageCount
                     )
-                    await imageStore.prepare(recipes: fetchedRecipes) { [weak self] prepared, total in
+                    let allImagesPrepared = await imageStore.prepare(
+                        recipes: fetchedRecipes
+                    ) { [weak self] prepared, total in
                         guard let self, generation == self.recipeFetchGeneration else {
                             return
                         }
@@ -408,11 +418,20 @@ final class DataManager: ObservableObject {
                         )
                     }
                     guard generation == recipeFetchGeneration else { return }
+                    guard allImagesPrepared else {
+                        shouldPersistRecipeBookLoadingError = true
+                        errorMessage = "Some recipe images couldn’t be downloaded. Please try again."
+                        accessibilityAnnouncement = errorMessage
+                        isLoading = false
+                        isManualSyncing = false
+                        return
+                    }
                 } else {
                     imageStore.prefetch(recipes: fetchedRecipes)
                 }
                 lastUpdated = Date()
                 lastRecipeFetch = Date()
+                shouldPersistRecipeBookLoadingError = false
                 isLoading = false
                 isManualSyncing = false
                 return
@@ -425,6 +444,7 @@ final class DataManager: ObservableObject {
                     continue
                 }
                 let type = errorType(for: error)
+                shouldPersistRecipeBookLoadingError = waitForImages
                 errorMessage = type.rawValue
                 accessibilityAnnouncement = type.rawValue
                 isLoading = false

--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -24,6 +24,12 @@ extension NSUbiquitousKeyValueStore: KeyValueStore {}
 
 @MainActor
 final class DataManager: ObservableObject {
+    enum RecipeBookLoadingPhase: Equatable {
+        case idle
+        case downloadingRecipes(downloaded: Int, total: Int?)
+        case preparingImages(prepared: Int, total: Int)
+    }
+
     @Published var recipes: [Recipe] = []
     @Published private(set) var chests: [RecipeChest] = []
     @Published var recentSearchNames: [String] = []
@@ -39,6 +45,7 @@ final class DataManager: ObservableObject {
     @Published var lastRecipeFetch: Date?
     @Published var isConnected: Bool = true
     @Published var consoleCommands: [ConsoleCommand] = []
+    @Published private(set) var recipeBookLoadingPhase: RecipeBookLoadingPhase = .idle
 
     private let iCloudFavoritesKey = "favoriteRecipes"
     private let iCloudChestsKey = "recipeChests.v1"
@@ -51,6 +58,9 @@ final class DataManager: ObservableObject {
     private let keyValueStore: any KeyValueStore
     private let imageStore: CraftImageStore
     private var recipeFetchGeneration = 0
+
+    private static let catalogRecordName = "craftify-catalog-current"
+    private static let catalogRecipeCountField = "recipeCount"
 
     enum ErrorType: String {
         case network = "Network issue, please try again later."
@@ -279,7 +289,11 @@ final class DataManager: ObservableObject {
         }
     }
 
-    func fetchRecipes(isManual: Bool = false, completion: @escaping () -> Void = {}) {
+    func fetchRecipes(
+        isManual: Bool = false,
+        waitForImages: Bool = false,
+        completion: @escaping () -> Void = {}
+    ) {
         if !isConnected {
             errorMessage = "No internet connection. Try again later."
             accessibilityAnnouncement = errorMessage
@@ -294,24 +308,42 @@ final class DataManager: ObservableObject {
             return
         }
 
-        loadData(isManual: isManual, completion: completion)
+        loadData(
+            isManual: isManual,
+            waitForImages: waitForImages,
+            completion: completion
+        )
     }
 
-    func loadData(isManual: Bool = false, completion: @escaping () -> Void) {
+    func loadData(
+        isManual: Bool = false,
+        waitForImages: Bool = false,
+        completion: @escaping () -> Void
+    ) {
         let generation = recipeFetchGeneration
         Task {
-            await loadData(isManual: isManual, generation: generation)
+            await loadData(
+                isManual: isManual,
+                waitForImages: waitForImages,
+                generation: generation
+            )
             completion()
         }
     }
 
-    func loadDataAsync(isManual: Bool = false) async {
+    func loadDataAsync(isManual: Bool = false, waitForImages: Bool = false) async {
         await withCheckedContinuation { continuation in
-            loadData(isManual: isManual) { continuation.resume() }
+            loadData(isManual: isManual, waitForImages: waitForImages) {
+                continuation.resume()
+            }
         }
     }
 
-    private func loadData(isManual: Bool, generation: Int) async {
+    private func loadData(
+        isManual: Bool,
+        waitForImages: Bool,
+        generation: Int
+    ) async {
         guard generation == recipeFetchGeneration else { return }
 
         isLoading = true
@@ -321,19 +353,60 @@ final class DataManager: ObservableObject {
         let database = CKContainer(identifier: "iCloud.craftifydb").publicCloudDatabase
         let query = CKQuery(recordType: "Recipe", predicate: NSPredicate(value: true))
 
+        recipeBookLoadingPhase = .downloadingRecipes(downloaded: 0, total: nil)
+        let catalogRecipeCount = await fetchCatalogRecipeCount(from: database)
+        guard generation == recipeFetchGeneration else { return }
+        recipeBookLoadingPhase = .downloadingRecipes(
+            downloaded: 0,
+            total: catalogRecipeCount
+        )
+
         for retryCount in 0...3 {
             guard generation == recipeFetchGeneration else { return }
 
             do {
-                let records = try await fetchAllRecords(matching: query, from: database)
+                let records = try await fetchAllRecords(
+                    matching: query,
+                    from: database
+                ) { [weak self] downloaded in
+                    guard let self, generation == self.recipeFetchGeneration else {
+                        return
+                    }
+                    self.recipeBookLoadingPhase = .downloadingRecipes(
+                        downloaded: downloaded,
+                        total: catalogRecipeCount.map { max($0, downloaded) }
+                    )
+                }
                 guard generation == recipeFetchGeneration else { return }
 
                 let fetchedRecipes = records.compactMap(convertRecordToRecipe)
+                let actualRecipeCount = fetchedRecipes.count
+                recipeBookLoadingPhase = .downloadingRecipes(
+                    downloaded: actualRecipeCount,
+                    total: max(catalogRecipeCount ?? 0, actualRecipeCount)
+                )
                 recipes = fetchedRecipes.sorted { $0.name < $1.name }
                 syncRecentSearches()
                 saveRecipesToLocalCache(fetchedRecipes)
+
                 if isManual {
                     await imageStore.refresh(recipes: fetchedRecipes)
+                    guard generation == recipeFetchGeneration else { return }
+                } else if waitForImages {
+                    let imageCount = CraftImageStore.imageKeys(in: fetchedRecipes).count
+                    recipeBookLoadingPhase = .preparingImages(
+                        prepared: 0,
+                        total: imageCount
+                    )
+                    await imageStore.prepare(recipes: fetchedRecipes) { [weak self] prepared, total in
+                        guard let self, generation == self.recipeFetchGeneration else {
+                            return
+                        }
+                        self.recipeBookLoadingPhase = .preparingImages(
+                            prepared: prepared,
+                            total: total
+                        )
+                    }
                     guard generation == recipeFetchGeneration else { return }
                 } else {
                     imageStore.prefetch(recipes: fetchedRecipes)
@@ -733,12 +806,34 @@ final class DataManager: ObservableObject {
         }
     }
 
-    private func fetchAllRecords(matching query: CKQuery, from database: CKDatabase) async throws -> [CKRecord] {
+    private func fetchCatalogRecipeCount(from database: CKDatabase) async -> Int? {
+        do {
+            let recordID = CKRecord.ID(recordName: Self.catalogRecordName)
+            let record = try await database.record(for: recordID)
+            guard let count = record[Self.catalogRecipeCountField] as? Int64,
+                  count >= 0 else {
+                return nil
+            }
+            return Int(count)
+        } catch {
+            if (error as? CKError)?.code != .unknownItem {
+                print("Could not fetch recipe catalog: \(error.localizedDescription)")
+            }
+            return nil
+        }
+    }
+
+    private func fetchAllRecords(
+        matching query: CKQuery,
+        from database: CKDatabase,
+        progress: ((Int) -> Void)? = nil
+    ) async throws -> [CKRecord] {
         var page = try await database.records(
             matching: query,
             resultsLimit: CKQueryOperation.maximumResults
         )
         var fetchedRecords = records(from: page.matchResults)
+        progress?(fetchedRecords.count)
 
         while let cursor = page.queryCursor {
             page = try await database.records(
@@ -746,6 +841,7 @@ final class DataManager: ObservableObject {
                 resultsLimit: CKQueryOperation.maximumResults
             )
             fetchedRecords.append(contentsOf: records(from: page.matchResults))
+            progress?(fetchedRecords.count)
         }
 
         return fetchedRecords

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct OnboardingView: View {
+    @EnvironmentObject private var dataManager: DataManager
+
     let title: String
     let message: String
     @Binding var isLoading: Bool
@@ -106,15 +108,7 @@ struct OnboardingView: View {
                     .accessibilityHint("Retries loading the Craftify recipe library")
                 }
             } else {
-                VStack(spacing: 12) {
-                    ProgressView()
-                        .controlSize(.large)
-                    Text("Building your recipe book…")
-                        .font(.footnote.weight(.medium))
-                        .foregroundStyle(.secondary)
-                }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Loading recipes")
+                recipeBookProgressView
             }
 
             Spacer()
@@ -125,6 +119,63 @@ struct OnboardingView: View {
         .padding(.horizontal, pagePadding)
         .padding(.vertical, 28)
         .frame(maxWidth: 620)
+    }
+
+    @ViewBuilder
+    private var recipeBookProgressView: some View {
+        VStack(spacing: 12) {
+            switch dataManager.recipeBookLoadingPhase {
+            case .idle:
+                ProgressView()
+                    .controlSize(.large)
+                Text("Building your recipe book…")
+                    .font(.footnote.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel("Building your recipe book")
+
+            case .downloadingRecipes(let downloaded, let total):
+                if let total {
+                    let displayedTotal = max(total, downloaded)
+                    ProgressView(
+                        value: Double(downloaded),
+                        total: Double(max(displayedTotal, 1))
+                    )
+                    .progressViewStyle(.linear)
+                    Text("Downloading recipes \(downloaded) / \(displayedTotal)")
+                        .font(.footnote.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
+                        .accessibilityLabel(
+                            "\(downloaded) of \(displayedTotal) recipes downloaded"
+                        )
+                } else {
+                    ProgressView()
+                        .controlSize(.large)
+                    Text("Downloading recipes… \(downloaded)")
+                        .font(.footnote.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                        .contentTransition(.numericText())
+                        .accessibilityLabel("\(downloaded) recipes downloaded")
+                }
+
+            case .preparingImages(let prepared, let total):
+                ProgressView(
+                    value: Double(total == 0 ? 1 : prepared),
+                    total: Double(max(total, 1))
+                )
+                .progressViewStyle(.linear)
+                Text("Preparing images \(prepared) / \(total)")
+                    .font(.footnote.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                    .accessibilityLabel("\(prepared) of \(total) images prepared")
+            }
+        }
+        .frame(maxWidth: 320)
+        .animation(.easeInOut(duration: 0.25), value: dataManager.recipeBookLoadingPhase)
     }
 
     private var onboardingPages: some View {


### PR DESCRIPTION
## What changed

- reads the singleton `CraftifyCatalog` record before querying recipes
- reports paginated recipe progress as `downloaded / total`
- reports preparation progress for the unique recipe and ingredient image keys
- waits for successful image preparation before showing the walkthrough on a genuine first launch
- keeps image failures on a persistent “Try Again” state instead of opening an incomplete library
- preserves background image refreshes for returning users and manual onboarding replays
- falls back to indeterminate recipe progress if the catalog record is unavailable
- expands a stale catalog total when CloudKit returns more records than expected

## User impact

First-time users remain on the “Building your recipe book” screen until recipes and their referenced images have been processed, with clear determinate progress wherever a catalog total is available.

## Validation

- reviewed the connector branch diff against `main`
- verified loading-generation guards remain in place around recipe and image work
- Craftify iOS CI run 171: passed
