### PR TITLE
Refine onboarding and announce new recipes

### DIFF
--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -93,6 +93,20 @@ struct ContentView: View {
                 )
                 .opacity(1)
                 .animation(.easeInOut(duration: 0.3), value: dataManager.isManualSyncing)
+                .zIndex(2)
+            }
+
+            if !dataManager.isManualSyncing,
+               let announcement = dataManager.newRecipeAnnouncement {
+                NewRecipesOverlayView(
+                    horizontalSizeClass: horizontalSizeClass,
+                    recipeCount: announcement.recipeCount
+                ) {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        dataManager.dismissNewRecipeAnnouncement()
+                    }
+                }
+                .zIndex(3)
             }
         }
         // 4) nav-bar material
@@ -103,6 +117,7 @@ struct ContentView: View {
                     .ignoresSafeArea()
             }
         }
+        .sensoryFeedback(.success, trigger: dataManager.newRecipeAnnouncement?.id)
         .onChange(of: selectedTab) { _, newValue in
             HapticFeedback.selection()
             UIAccessibility.post(

--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -30,6 +30,11 @@ final class DataManager: ObservableObject {
         case preparingImages(prepared: Int, total: Int)
     }
 
+    struct NewRecipeAnnouncement: Identifiable, Equatable {
+        let id = UUID()
+        let recipeCount: Int
+    }
+
     @Published var recipes: [Recipe] = []
     @Published private(set) var chests: [RecipeChest] = []
     @Published var recentSearchNames: [String] = []
@@ -46,6 +51,7 @@ final class DataManager: ObservableObject {
     @Published var isConnected: Bool = true
     @Published var consoleCommands: [ConsoleCommand] = []
     @Published private(set) var recipeBookLoadingPhase: RecipeBookLoadingPhase = .idle
+    @Published private(set) var newRecipeAnnouncement: NewRecipeAnnouncement?
 
     private let iCloudFavoritesKey = "favoriteRecipes"
     private let iCloudChestsKey = "recipeChests.v1"
@@ -57,11 +63,13 @@ final class DataManager: ObservableObject {
     private let networkQueue = DispatchQueue(label: "NetworkMonitor")
     private let keyValueStore: any KeyValueStore
     private let imageStore: CraftImageStore
+    private let defaults: UserDefaults
     private var recipeFetchGeneration = 0
     private var shouldPersistRecipeBookLoadingError = false
 
     private static let catalogRecordName = "craftify-catalog-current"
     private static let catalogRecipeCountField = "recipeCount"
+    private static let knownRecipeIDsDefaultsKey = "knownRecipeIDs.v1"
 
     enum ErrorType: String {
         case network = "Network issue, please try again later."
@@ -74,10 +82,12 @@ final class DataManager: ObservableObject {
 
     init(
         keyValueStore: any KeyValueStore = NSUbiquitousKeyValueStore.default,
-        imageStore: CraftImageStore = .shared
+        imageStore: CraftImageStore = .shared,
+        defaults: UserDefaults = .standard
     ) {
         self.keyValueStore = keyValueStore
         self.imageStore = imageStore
+        self.defaults = defaults
         keyValueStore.synchronize()
 
         networkMonitor.pathUpdateHandler = { [weak self] path in
@@ -134,6 +144,7 @@ final class DataManager: ObservableObject {
             print("Loaded \(localRecipes.count) recipes from local cache.")
             self.recipes = localRecipes.sorted(by: { $0.name < $1.name })
             self.syncRecentSearches()
+            seedKnownRecipeIDsIfNeeded(from: localRecipes)
             imageStore.prefetch(recipes: localRecipes)
         } else {
             print("No local cache found; will fetch from CloudKit on first view load.")
@@ -429,6 +440,7 @@ final class DataManager: ObservableObject {
                 } else {
                     imageStore.prefetch(recipes: fetchedRecipes)
                 }
+                recordSuccessfulRecipeLibrary(fetchedRecipes)
                 lastUpdated = Date()
                 lastRecipeFetch = Date()
                 shouldPersistRecipeBookLoadingError = false
@@ -451,6 +463,43 @@ final class DataManager: ObservableObject {
                 isManualSyncing = false
                 return
             }
+        }
+    }
+
+    func dismissNewRecipeAnnouncement() {
+        newRecipeAnnouncement = nil
+    }
+
+    private func seedKnownRecipeIDsIfNeeded(from recipes: [Recipe]) {
+        guard storedKnownRecipeIDs() == nil else { return }
+        saveKnownRecipeIDs(Set(recipes.map(\.id)))
+    }
+
+    private func recordSuccessfulRecipeLibrary(_ recipes: [Recipe]) {
+        let fetchedIDs = Set(recipes.map(\.id))
+        defer { saveKnownRecipeIDs(fetchedIDs) }
+
+        guard let knownIDs = storedKnownRecipeIDs() else { return }
+        let addedCount = fetchedIDs.subtracting(knownIDs).count
+        guard addedCount > 0 else { return }
+
+        newRecipeAnnouncement = NewRecipeAnnouncement(recipeCount: addedCount)
+    }
+
+    private func storedKnownRecipeIDs() -> Set<Int>? {
+        guard let data = defaults.data(forKey: Self.knownRecipeIDsDefaultsKey),
+              let ids = try? JSONDecoder().decode([Int].self, from: data) else {
+            return nil
+        }
+        return Set(ids)
+    }
+
+    private func saveKnownRecipeIDs(_ ids: Set<Int>) {
+        do {
+            let data = try JSONEncoder().encode(ids.sorted())
+            defaults.set(data, forKey: Self.knownRecipeIDsDefaultsKey)
+        } catch {
+            print("Could not save known recipe IDs: \(error.localizedDescription)")
         }
     }
 
@@ -651,6 +700,7 @@ final class DataManager: ObservableObject {
             try imageStore.clearDownloadedImages()
 
             recipes = []
+            newRecipeAnnouncement = nil
             lastRecipeFetch = nil
             lastUpdated = nil
             cacheClearedMessage = "Recipe and image data cleared successfully."

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -124,10 +124,13 @@ struct OnboardingView: View {
     @ViewBuilder
     private var recipeBookProgressView: some View {
         VStack(spacing: 12) {
+            ProgressView()
+                .controlSize(.large)
+                .tint(Color.userAccentColor)
+                .accessibilityHidden(true)
+
             switch dataManager.recipeBookLoadingPhase {
             case .idle:
-                ProgressView()
-                    .controlSize(.large)
                 Text("Building your recipe book…")
                     .font(.footnote.weight(.medium))
                     .foregroundStyle(.secondary)
@@ -141,6 +144,7 @@ struct OnboardingView: View {
                         total: Double(max(displayedTotal, 1))
                     )
                     .progressViewStyle(.linear)
+                    .accessibilityHidden(true)
                     Text("Downloading recipes \(downloaded) / \(displayedTotal)")
                         .font(.footnote.weight(.medium))
                         .foregroundStyle(.secondary)
@@ -150,8 +154,6 @@ struct OnboardingView: View {
                             "\(downloaded) of \(displayedTotal) recipes downloaded"
                         )
                 } else {
-                    ProgressView()
-                        .controlSize(.large)
                     Text("Downloading recipes… \(downloaded)")
                         .font(.footnote.weight(.medium))
                         .foregroundStyle(.secondary)
@@ -166,6 +168,7 @@ struct OnboardingView: View {
                     total: Double(max(total, 1))
                 )
                 .progressViewStyle(.linear)
+                .accessibilityHidden(true)
                 Text("Preparing images \(prepared) / \(total)")
                     .font(.footnote.weight(.medium))
                     .foregroundStyle(.secondary)
@@ -475,6 +478,16 @@ private struct OnboardingPage {
             highlights: [
                 Highlight(symbol: "square.grid.2x2", text: "Browse a complete, organized recipe library"),
                 Highlight(symbol: "sparkles", text: "Discover a fresh selection of Craftify Picks")
+            ]
+        ),
+        OnboardingPage(
+            eyebrow: "Ready anywhere",
+            title: "Craft anywhere",
+            detail: "Your downloaded recipe book stays on this device, so you can keep crafting without an internet connection.",
+            symbol: "wifi.slash",
+            highlights: [
+                Highlight(symbol: "hammer.fill", text: "No signal? No crafting-table crisis—your recipes and images remain ready offline"),
+                Highlight(symbol: "icloud.and.arrow.down.fill", text: "Connect now and then to collect new recipes and image updates")
             ]
         ),
         OnboardingPage(

--- a/Craftify/SyncOverlayView.swift
+++ b/Craftify/SyncOverlayView.swift
@@ -11,8 +11,89 @@ struct SyncOverlayView: View {
     let horizontalSizeClass: UserInterfaceSizeClass?
     let message: String
 
+    var body: some View {
+        CraftifyOverlayCard(
+            horizontalSizeClass: horizontalSizeClass,
+            title: message,
+            detail: "Gathering the latest recipes from the cloud",
+            symbol: "book.closed.fill",
+            badgeSymbol: "icloud.fill"
+        ) {
+            ProgressView()
+                .tint(Color.userAccentColor)
+                .controlSize(.small)
+                .accessibilityHidden(true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(message). Gathering the latest recipes from the cloud")
+        .accessibilityHint("Please wait. This view closes automatically when syncing is complete.")
+    }
+}
+
+struct NewRecipesOverlayView: View {
+    let horizontalSizeClass: UserInterfaceSizeClass?
+    let recipeCount: Int
+    let onDismiss: () -> Void
+
+    private var title: String {
+        recipeCount == 1 ? "A New Recipe Arrived!" : "\(recipeCount) New Recipes Arrived!"
+    }
+
+    private var detail: String {
+        recipeCount == 1
+            ? "A fresh crafting idea just landed in your recipe book."
+            : "Fresh crafting ideas just landed in your recipe book."
+    }
+
+    var body: some View {
+        CraftifyOverlayCard(
+            horizontalSizeClass: horizontalSizeClass,
+            title: title,
+            detail: detail,
+            symbol: "book.closed.fill",
+            badgeSymbol: "sparkles"
+        ) {
+            Button(action: onDismiss) {
+                Label("Explore Recipes", systemImage: "hammer.fill")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .tint(Color.userAccentColor)
+            .accessibilityHint("Dismisses this message and opens your recipe library")
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+    }
+}
+
+private struct CraftifyOverlayCard<Footer: View>: View {
+    let horizontalSizeClass: UserInterfaceSizeClass?
+    let title: String
+    let detail: String
+    let symbol: String
+    let badgeSymbol: String
+    let footer: Footer
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isAnimating = false
+
+    init(
+        horizontalSizeClass: UserInterfaceSizeClass?,
+        title: String,
+        detail: String,
+        symbol: String,
+        badgeSymbol: String,
+        @ViewBuilder footer: () -> Footer
+    ) {
+        self.horizontalSizeClass = horizontalSizeClass
+        self.title = title
+        self.detail = detail
+        self.symbol = symbol
+        self.badgeSymbol = badgeSymbol
+        self.footer = footer()
+    }
 
     private var cardWidth: CGFloat {
         horizontalSizeClass == .regular ? 420 : 330
@@ -24,24 +105,22 @@ struct SyncOverlayView: View {
                 .ignoresSafeArea()
 
             VStack(spacing: 20) {
-                syncIllustration
+                illustration
 
                 VStack(spacing: 7) {
-                    Text(message)
+                    Text(title)
                         .font(.title3.weight(.semibold))
                         .foregroundStyle(.primary)
+                        .multilineTextAlignment(.center)
 
-                    Text("Gathering the latest recipes from the cloud")
+                    Text(detail)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .fixedSize(horizontal: false, vertical: true)
                 }
 
-                ProgressView()
-                    .tint(Color.userAccentColor)
-                    .controlSize(.small)
-                    .accessibilityHidden(true)
+                footer
             }
             .padding(.horizontal, 28)
             .padding(.vertical, 30)
@@ -57,13 +136,10 @@ struct SyncOverlayView: View {
         .onAppear { isAnimating = true }
         .onDisappear { isAnimating = false }
         .transition(.opacity.combined(with: .scale(scale: 0.97)))
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(message). Gathering the latest recipes from the cloud")
-        .accessibilityHint("Please wait. This view closes automatically when syncing is complete.")
         .accessibilityAddTraits(.isModal)
     }
 
-    private var syncIllustration: some View {
+    private var illustration: some View {
         ZStack {
             Circle()
                 .fill(Color.userAccentColor.opacity(0.10))
@@ -80,13 +156,13 @@ struct SyncOverlayView: View {
                 .frame(width: 76, height: 76)
                 .shadow(color: Color.userAccentColor.opacity(0.24), radius: 14, y: 7)
 
-            Image(systemName: "book.closed.fill")
+            Image(systemName: symbol)
                 .font(.system(size: 32, weight: .semibold))
                 .foregroundStyle(.white)
 
-            Image(systemName: "icloud.fill")
+            Image(systemName: badgeSymbol)
                 .font(.system(size: 19, weight: .semibold))
-                .foregroundStyle(Color.userAccentColor, Color(.systemGroupedBackground))
+                .foregroundStyle(Color.userAccentColor)
                 .padding(7)
                 .background(.regularMaterial, in: Circle())
                 .offset(x: 35, y: 35)


### PR DESCRIPTION
## What changed

- keeps the circular activity indicator visible while both recipe and image determinate progress bars advance
- adds a dedicated onboarding page explaining offline availability and occasional online updates in end-user language
- adds a returning-user celebration when newly added recipe IDs are downloaded
- reuses the existing sync overlay card, animation, material, colors, and responsive sizing for visual consistency
- stores the known recipe IDs per device so cache clearing does not make the complete catalog appear new
- delays the celebration until any manual sync overlay has finished and includes a success haptic

## New recipe counting

The announcement compares the successfully fetched recipe IDs with the IDs previously known on that device. This is more accurate than subtracting catalog totals when recipes are deleted or replaced.

On a first install, the initial catalog becomes the baseline and no “all recipes are new” popup is shown. Existing installations seed the baseline from their persistent recipe cache, allowing genuinely new recipes to be announced after the upgrade.

## User-facing copy

The new onboarding page explains that downloaded recipes and images remain available offline, with the line:

> No signal? No crafting-table crisis—your recipes and images remain ready offline

It also recommends connecting occasionally for new recipes and image updates.

## Validation

- reviewed the connector branch diff against `main`
- verified known recipe metadata survives recipe-cache clearing to prevent false announcements
- Craftify iOS CI run 173: passed
