### PR TITLE
Show exact new recipes in the sync overlay

### DIFF
--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -100,12 +100,13 @@ struct ContentView: View {
                let announcement = dataManager.newRecipeAnnouncement {
                 NewRecipesOverlayView(
                     horizontalSizeClass: horizontalSizeClass,
-                    recipeCount: announcement.recipeCount
+                    recipes: announcement.recipes
                 ) {
                     withAnimation(.easeInOut(duration: 0.25)) {
                         dataManager.dismissNewRecipeAnnouncement()
                     }
                 }
+                .id(announcement.id)
                 .zIndex(3)
             }
         }

--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -32,7 +32,11 @@ final class DataManager: ObservableObject {
 
     struct NewRecipeAnnouncement: Identifiable, Equatable {
         let id = UUID()
-        let recipeCount: Int
+        let recipes: [Recipe]
+
+        var recipeCount: Int {
+            recipes.count
+        }
     }
 
     @Published var recipes: [Recipe] = []
@@ -480,10 +484,23 @@ final class DataManager: ObservableObject {
         defer { saveKnownRecipeIDs(fetchedIDs) }
 
         guard let knownIDs = storedKnownRecipeIDs() else { return }
-        let addedCount = fetchedIDs.subtracting(knownIDs).count
-        guard addedCount > 0 else { return }
+        let addedRecipes = Self.newlyAddedRecipes(
+            in: recipes,
+            comparedTo: knownIDs
+        )
+        guard !addedRecipes.isEmpty else { return }
 
-        newRecipeAnnouncement = NewRecipeAnnouncement(recipeCount: addedCount)
+        newRecipeAnnouncement = NewRecipeAnnouncement(recipes: addedRecipes)
+    }
+
+    static func newlyAddedRecipes(
+        in recipes: [Recipe],
+        comparedTo knownIDs: Set<Int>
+    ) -> [Recipe] {
+        let addedIDs = Set(recipes.map(\.id)).subtracting(knownIDs)
+        return recipes
+            .filter { addedIDs.contains($0.id) }
+            .sorted { $0.id < $1.id }
     }
 
     private func storedKnownRecipeIDs() -> Set<Int>? {

--- a/Craftify/SyncOverlayView.swift
+++ b/Craftify/SyncOverlayView.swift
@@ -31,18 +31,45 @@ struct SyncOverlayView: View {
 }
 
 struct NewRecipesOverlayView: View {
+    private enum Page: Equatable {
+        case summary
+        case recipeList
+    }
+
     let horizontalSizeClass: UserInterfaceSizeClass?
-    let recipeCount: Int
+    let recipes: [Recipe]
     let onDismiss: () -> Void
 
+    @State private var page: Page = .summary
+
+    private var recipeCount: Int {
+        recipes.count
+    }
+
     private var title: String {
-        recipeCount == 1 ? "A New Recipe Arrived!" : "\(recipeCount) New Recipes Arrived!"
+        switch page {
+        case .summary:
+            recipeCount == 1
+                ? "A New Recipe Arrived!"
+                : "\(recipeCount) New Recipes Arrived!"
+        case .recipeList:
+            recipeCount == 1 ? "Meet the New Recipe" : "Meet the New Recipes"
+        }
     }
 
     private var detail: String {
-        recipeCount == 1
-            ? "A fresh crafting idea just landed in your recipe book."
-            : "Fresh crafting ideas just landed in your recipe book."
+        switch page {
+        case .summary:
+            recipeCount == 1
+                ? "A fresh crafting idea just landed in your recipe book."
+                : "Fresh crafting ideas just landed in your recipe book."
+        case .recipeList:
+            "Added since your last successful recipe sync."
+        }
+    }
+
+    private var reviewButtonTitle: String {
+        recipeCount == 1 ? "Review New Recipe" : "Review New Recipes"
     }
 
     var body: some View {
@@ -51,20 +78,131 @@ struct NewRecipesOverlayView: View {
             title: title,
             detail: detail,
             symbol: "book.closed.fill",
-            badgeSymbol: "sparkles"
+            badgeSymbol: page == .summary ? "sparkles" : "list.bullet",
+            showsIllustration: page == .summary
         ) {
-            Button(action: onDismiss) {
-                Label("Explore Recipes", systemImage: "hammer.fill")
+            switch page {
+            case .summary:
+                summaryActions
+            case .recipeList:
+                recipeListContent
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: page)
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+    }
+
+    private var summaryActions: some View {
+        VStack(spacing: 10) {
+            exploreButton
+
+            Button {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    page = .recipeList
+                }
+            } label: {
+                Label(reviewButtonTitle, systemImage: "list.bullet")
                     .font(.headline)
                     .frame(maxWidth: .infinity)
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(.bordered)
             .controlSize(.large)
             .tint(Color.userAccentColor)
-            .accessibilityHint("Dismisses this message and opens your recipe library")
+            .accessibilityHint("Shows the names and record IDs of the newly added recipes")
         }
-        .accessibilityElement(children: .contain)
-        .accessibilityAddTraits(.isModal)
+    }
+
+    private var recipeListContent: some View {
+        VStack(spacing: 12) {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(recipes) { recipe in
+                        NewRecipeAnnouncementRow(recipe: recipe)
+
+                        if recipe.id != recipes.last?.id {
+                            Divider()
+                                .padding(.leading, 64)
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 280)
+            .background(
+                Color.primary.opacity(0.045),
+                in: RoundedRectangle(cornerRadius: 16, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+            }
+            .accessibilityLabel("New recipes")
+
+            exploreButton
+
+            Button {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    page = .summary
+                }
+            } label: {
+                Label("Back", systemImage: "chevron.left")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
+            .tint(Color.userAccentColor)
+            .accessibilityHint("Returns to the new recipe summary")
+        }
+    }
+
+    private var exploreButton: some View {
+        Button(action: onDismiss) {
+            Label("Explore Recipes", systemImage: "hammer.fill")
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .tint(Color.userAccentColor)
+        .accessibilityHint("Dismisses this message and opens your recipe library")
+    }
+}
+
+private struct NewRecipeAnnouncementRow: View {
+    let recipe: Recipe
+
+    private var metadata: String {
+        recipe.category.isEmpty
+            ? "Record ID \(recipe.id)"
+            : "Record ID \(recipe.id) • \(recipe.category)"
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            CraftImage(key: recipe.image)
+                .scaledToFit()
+                .frame(width: 44, height: 44)
+                .padding(4)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(recipe.name)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.leading)
+
+                Text(metadata)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(recipe.name), \(metadata)")
     }
 }
 
@@ -74,6 +212,7 @@ private struct CraftifyOverlayCard<Footer: View>: View {
     let detail: String
     let symbol: String
     let badgeSymbol: String
+    let showsIllustration: Bool
     let footer: Footer
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -85,6 +224,7 @@ private struct CraftifyOverlayCard<Footer: View>: View {
         detail: String,
         symbol: String,
         badgeSymbol: String,
+        showsIllustration: Bool = true,
         @ViewBuilder footer: () -> Footer
     ) {
         self.horizontalSizeClass = horizontalSizeClass
@@ -92,6 +232,7 @@ private struct CraftifyOverlayCard<Footer: View>: View {
         self.detail = detail
         self.symbol = symbol
         self.badgeSymbol = badgeSymbol
+        self.showsIllustration = showsIllustration
         self.footer = footer()
     }
 
@@ -105,7 +246,9 @@ private struct CraftifyOverlayCard<Footer: View>: View {
                 .ignoresSafeArea()
 
             VStack(spacing: 20) {
-                illustration
+                if showsIllustration {
+                    illustration
+                }
 
                 VStack(spacing: 7) {
                     Text(title)

--- a/CraftifyTests/CraftifyTests.swift
+++ b/CraftifyTests/CraftifyTests.swift
@@ -236,3 +236,51 @@ extension CraftifyTests {
         #expect(defaults.object(forKey: versionKey) == nil)
     }
 }
+
+extension CraftifyTests {
+    @MainActor
+    @Test func newRecipeAnnouncementContainsExactRecipesSortedByRecordID() {
+        let recipes = [
+            announcementRecipe(id: 351, name: "Spruce Chest Boat"),
+            announcementRecipe(id: 12, name: "Existing Recipe"),
+            announcementRecipe(id: 349, name: "Oak Boat with Chest")
+        ]
+
+        let addedRecipes = DataManager.newlyAddedRecipes(
+            in: recipes,
+            comparedTo: [12]
+        )
+
+        #expect(addedRecipes.map(\.id) == [349, 351])
+        #expect(
+            addedRecipes.map(\.name)
+                == ["Oak Boat with Chest", "Spruce Chest Boat"]
+        )
+
+        let announcement = DataManager.NewRecipeAnnouncement(
+            recipes: addedRecipes
+        )
+        #expect(announcement.recipeCount == 2)
+    }
+
+    private func announcementRecipe(id: Int, name: String) -> Recipe {
+        Recipe(
+            id: id,
+            name: name,
+            image: name,
+            ingredients: ["Oak Planks"],
+            alternateIngredients: nil,
+            alternateIngredients1: nil,
+            alternateIngredients2: nil,
+            alternateIngredients3: nil,
+            output: 1,
+            alternateOutput: nil,
+            alternateOutput1: nil,
+            alternateOutput2: nil,
+            alternateOutput3: nil,
+            category: "Test",
+            imageremark: nil,
+            remarks: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- carry the exact newly added `Recipe` objects in the returning-user announcement instead of only a count
- derive additions from the existing persisted set of known numeric recipe IDs
- add a secondary **Review New Recipes** action to the sync overlay
- show a scrollable second page with each recipe’s image, name, CloudKit-derived record ID, and category
- preserve the existing **Explore Recipes** action on both overlay pages
- reset the overlay page when a different announcement arrives
- add a Swift Testing regression test for exact, non-consecutive additions

## How it works

No extra CloudKit request is needed. After the existing paginated recipe fetch succeeds, Craftify compares the fetched recipe ID set with `knownRecipeIDs.v1`. It retains the matching newly fetched `Recipe` values, sorts them by numeric ID, and presents those values in the announcement.

This means gaps in record IDs are safe: for example, IDs 349 and 351 are both reported even if 350 already existed or is absent. Updates to a recipe with an already-known ID are not incorrectly announced as new.

## User experience

The current announcement remains the first page. Users can:

- choose **Explore Recipes** immediately, exactly as before
- choose **Review New Recipe(s)** to see the exact additions
- return with **Back**, or dismiss via **Explore Recipes**

The detail page omits the large illustration to leave room for a bounded, scrollable list and Dynamic Type.

## Validation

- confirmed the branch is based on current `main` with no divergence
- verified all four connector branch files exactly match the intended source
- checked balanced Swift delimiters and all announcement call sites
- added a unit test asserting IDs 349 and 351, names, order, and count
- GitHub Actions should run the existing iOS 18 build-and-test workflow on this PR
