### PR TITLE
Display animated GIF recipe artwork

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,7 +1,7 @@
 name: Craftify iOS CI
+
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   push:
@@ -12,70 +12,70 @@ on:
 
 jobs:
   build-and-test:
-    name: Build and Test Craftify on iPhone 15 Simulator (iOS 18.0)
-    runs-on: macos-latest
+    name: Build and test Craftify on iOS/iPadOS 26
+    runs-on: macos-26
     timeout-minutes: 30
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@v5
 
-      - name: Select Xcode Version
+      - name: Show Apple toolchain
         run: |
-          # List available Xcode installations
-          ls -ld /Applications/Xcode*.app
-          # Try common Xcode paths
-          XCODE_PATH=$(find /Applications -maxdepth 1 -name "Xcode*.app" | head -n 1)
-          if [ -z "$XCODE_PATH" ]; then
-            echo "No Xcode installation found"
+          xcodebuild -version
+          echo "iOS Simulator SDK: $(xcrun --sdk iphonesimulator --show-sdk-version)"
+
+      - name: Select an available iOS Simulator
+        run: |
+          SIMULATOR_ID="$(
+            xcrun simctl list devices available -j |
+              jq -r '
+                .devices
+                | to_entries[]
+                | select(.key | contains("iOS"))
+                | .value[]
+                | select(.isAvailable == true)
+                | .udid
+              ' |
+              head -n 1
+          )"
+
+          if [ -z "$SIMULATOR_ID" ]; then
+            echo "No available iOS Simulator was found."
             exit 1
           fi
-          sudo xcode-select -s "$XCODE_PATH/Contents/Developer"
-          xcodebuild -version
-          echo "Selected Xcode at $XCODE_PATH"
 
-      - name: Build
-        env:
-          SCHEME: Craftify
-          PLATFORM: iOS Simulator
-          DESTINATION: platform=iOS Simulator,name=iPhone 15,OS=18.0
-        run: |
-          xcodebuild clean build-for-testing \
-            -scheme "$SCHEME" \
-            -project "Craftify.xcodeproj" \
-            -destination "$DESTINATION" \
-            CODE_SIGNING_ALLOWED=NO | xcpretty
-          echo "Build completed successfully"
+          echo "SIMULATOR_DESTINATION=platform=iOS Simulator,id=$SIMULATOR_ID" >> "$GITHUB_ENV"
 
-      - name: Test
-        env:
-          SCHEME: Craftify
-          PLATFORM: iOS Simulator
-          DESTINATION: platform=iOS Simulator,name=iPhone 15,OS=18.0
+      - name: Build and run unit tests
         run: |
           xcodebuild test \
-            -scheme "$SCHEME" \
             -project "Craftify.xcodeproj" \
-            -destination "$DESTINATION" \
-            -enableSwiftTesting \
-            -testProductsPath "CraftifyTests" \
-            -testProductsPath "CraftifyUITests" \
+            -scheme "Craftify" \
+            -destination "$SIMULATOR_DESTINATION" \
+            -derivedDataPath "$RUNNER_TEMP/CraftifyDerivedData" \
+            -resultBundlePath "$RUNNER_TEMP/CraftifyTests.xcresult" \
             -enableCodeCoverage YES \
-            CODE_SIGNING_ALLOWED=NO | xcpretty
-          echo "Tests completed successfully"
+            -skip-testing:CraftifyUITests \
+            IPHONEOS_DEPLOYMENT_TARGET=18.0 \
+            CODE_SIGNING_ALLOWED=NO \
+            ENABLE_PREVIEWS=NO \
+            COMPILER_INDEX_STORE_ENABLE=NO
 
-      - name: Archive Code Coverage
+      - name: Create code coverage report
         if: always()
         run: |
-          xcrun xccov view --report --only-covered-files \
-            $(find DerivedData -name "*.xcresult" -type d) \
-            > coverage.txt
-          echo "Coverage report generated"
-        continue-on-error: true
+          if [ -d "$RUNNER_TEMP/CraftifyTests.xcresult" ]; then
+            xcrun xccov view \
+              --report \
+              "$RUNNER_TEMP/CraftifyTests.xcresult" \
+              > coverage.txt
+          fi
 
-      - name: Upload Coverage Artifact
+      - name: Upload code coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: code-coverage-report
           path: coverage.txt
+          if-no-files-found: ignore

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -58,12 +58,10 @@ jobs:
             -enableCodeCoverage YES \
             -skip-testing:CraftifyUITests \
             IPHONEOS_DEPLOYMENT_TARGET=18.0 \
-            CODE_SIGNING_ALLOWED=NO \
             ENABLE_PREVIEWS=NO \
             COMPILER_INDEX_STORE_ENABLE=NO
 
       - name: Create code coverage report
-        if: always()
         run: |
           if [ -d "$RUNNER_TEMP/CraftifyTests.xcresult" ]; then
             xcrun xccov view \
@@ -73,7 +71,6 @@ jobs:
           fi
 
       - name: Upload code coverage
-        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: code-coverage-report

--- a/Craftify/AnimatedImageView.swift
+++ b/Craftify/AnimatedImageView.swift
@@ -1,0 +1,154 @@
+//
+//  AnimatedImageView.swift
+//  Craftify
+//
+//  Native PNG and animated GIF rendering.
+//
+
+import ImageIO
+import SwiftUI
+import UIKit
+
+enum CraftImageData {
+    static func isValidImage(_ data: Data) -> Bool {
+        guard
+            !data.isEmpty,
+            let source = CGImageSourceCreateWithData(data as CFData, nil),
+            CGImageSourceGetCount(source) > 0
+        else {
+            return false
+        }
+
+        return CGImageSourceCreateImageAtIndex(source, 0, nil) != nil
+    }
+}
+
+struct AnimatedImageView: View {
+    let data: Data
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        AnimatedUIImageView(
+            data: data,
+            animates: !reduceMotion
+        )
+    }
+}
+
+private struct AnimatedUIImageView: UIViewRepresentable {
+    let data: Data
+    let animates: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeUIView(context: Context) -> UIImageView {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .clear
+        imageView.contentMode = .scaleAspectFit
+        imageView.clipsToBounds = true
+        imageView.layer.magnificationFilter = .nearest
+        return imageView
+    }
+
+    func updateUIView(_ imageView: UIImageView, context: Context) {
+        guard
+            context.coordinator.data != data ||
+            context.coordinator.animates != animates
+        else {
+            return
+        }
+
+        context.coordinator.data = data
+        context.coordinator.animates = animates
+        imageView.image = AnimatedUIImageDecoder.image(
+            from: data,
+            animates: animates
+        )
+    }
+
+    final class Coordinator {
+        var data: Data?
+        var animates = false
+    }
+}
+
+private enum AnimatedUIImageDecoder {
+    static func image(from data: Data, animates: Bool) -> UIImage? {
+        guard
+            let source = CGImageSourceCreateWithData(data as CFData, nil),
+            CGImageSourceGetCount(source) > 0
+        else {
+            return nil
+        }
+
+        let frameCount = CGImageSourceGetCount(source)
+        guard animates, frameCount > 1 else {
+            guard let frame = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
+                return UIImage(data: data)
+            }
+            return UIImage(
+                cgImage: frame,
+                scale: UIScreen.main.scale,
+                orientation: .up
+            )
+        }
+
+        var frames: [UIImage] = []
+        var totalDuration: TimeInterval = 0
+        frames.reserveCapacity(frameCount)
+
+        for index in 0..<frameCount {
+            guard let frame = CGImageSourceCreateImageAtIndex(source, index, nil) else {
+                continue
+            }
+
+            frames.append(
+                UIImage(
+                    cgImage: frame,
+                    scale: UIScreen.main.scale,
+                    orientation: .up
+                )
+            )
+            totalDuration += frameDuration(at: index, in: source)
+        }
+
+        guard !frames.isEmpty else { return nil }
+        guard frames.count > 1 else { return frames[0] }
+
+        return UIImage.animatedImage(
+            with: frames,
+            duration: max(totalDuration, 0.1)
+        ) ?? frames[0]
+    }
+
+    private static func frameDuration(
+        at index: Int,
+        in source: CGImageSource
+    ) -> TimeInterval {
+        guard
+            let properties = CGImageSourceCopyPropertiesAtIndex(
+                source,
+                index,
+                nil
+            ) as? [CFString: Any],
+            let gifProperties = properties[
+                kCGImagePropertyGIFDictionary
+            ] as? [CFString: Any]
+        else {
+            return 0.1
+        }
+
+        let unclamped = gifProperties[
+            kCGImagePropertyGIFUnclampedDelayTime
+        ] as? NSNumber
+        let clamped = gifProperties[
+            kCGImagePropertyGIFDelayTime
+        ] as? NSNumber
+        let duration = unclamped?.doubleValue ?? clamped?.doubleValue ?? 0.1
+
+        return duration < 0.02 ? 0.1 : duration
+    }
+}

--- a/Craftify/AnimatedImageView.swift
+++ b/Craftify/AnimatedImageView.swift
@@ -2,12 +2,18 @@
 //  AnimatedImageView.swift
 //  Craftify
 //
-//  Native PNG and animated GIF rendering.
+//  Shared PNG and animated GIF rendering for macOS, iOS, and iPadOS.
 //
 
 import ImageIO
 import SwiftUI
+import UniformTypeIdentifiers
+
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 enum CraftImageData {
     static func isValidImage(_ data: Data) -> Bool {
@@ -21,6 +27,26 @@ enum CraftImageData {
 
         return CGImageSourceCreateImageAtIndex(source, 0, nil) != nil
     }
+
+    static func preferredFilenameExtension(
+        for data: Data,
+        fallback: String = "png"
+    ) -> String {
+        let cleanedFallback = fallback
+            .lowercased()
+            .filter { $0.isLetter || $0.isNumber }
+
+        guard
+            let source = CGImageSourceCreateWithData(data as CFData, nil),
+            let typeIdentifier = CGImageSourceGetType(source),
+            let detectedExtension = UTType(typeIdentifier as String)?
+                .preferredFilenameExtension
+        else {
+            return cleanedFallback.isEmpty ? "png" : cleanedFallback
+        }
+
+        return detectedExtension.lowercased()
+    }
 }
 
 struct AnimatedImageView: View {
@@ -29,14 +55,15 @@ struct AnimatedImageView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        AnimatedUIImageView(
+        PlatformAnimatedImageView(
             data: data,
             animates: !reduceMotion
         )
     }
 }
 
-private struct AnimatedUIImageView: UIViewRepresentable {
+#if canImport(UIKit)
+private struct PlatformAnimatedImageView: UIViewRepresentable {
     let data: Data
     let animates: Bool
 
@@ -61,75 +88,298 @@ private struct AnimatedUIImageView: UIViewRepresentable {
             return
         }
 
-        context.coordinator.data = data
-        context.coordinator.animates = animates
-        imageView.image = AnimatedUIImageDecoder.image(
-            from: data,
+        context.coordinator.display(
+            data: data,
             animates: animates,
-            scale: context.environment.displayScale
+            scale: context.environment.displayScale,
+            in: imageView
         )
     }
 
+    static func dismantleUIView(
+        _ imageView: UIImageView,
+        coordinator: Coordinator
+    ) {
+        coordinator.stop()
+    }
+
+    @MainActor
     final class Coordinator {
         var data: Data?
         var animates = false
+        private var renderTask: Task<Void, Never>?
+
+        func display(
+            data: Data,
+            animates: Bool,
+            scale: CGFloat,
+            in imageView: UIImageView
+        ) {
+            self.data = data
+            self.animates = animates
+            renderTask?.cancel()
+            imageView.image = nil
+
+            renderTask = Task { @MainActor [weak imageView] in
+                guard let descriptor = await AnimatedImagePipeline.shared
+                    .descriptor(for: data),
+                      !Task.isCancelled
+                else {
+                    return
+                }
+
+                if animates && descriptor.canAnimate {
+                    await Self.animate(
+                        descriptor: descriptor,
+                        data: data,
+                        scale: scale,
+                        in: imageView
+                    )
+                } else {
+                    guard
+                        let frame = await AnimatedImagePipeline.shared.frame(
+                            at: 0,
+                            for: data
+                        ),
+                        !Task.isCancelled
+                    else {
+                        return
+                    }
+
+                    imageView?.image = UIImage(
+                        cgImage: frame.image,
+                        scale: max(scale, 1),
+                        orientation: .up
+                    )
+                }
+            }
+        }
+
+        func stop() {
+            renderTask?.cancel()
+            renderTask = nil
+        }
+
+        private static func animate(
+            descriptor: AnimatedImageDescriptor,
+            data: Data,
+            scale: CGFloat,
+            in imageView: UIImageView?
+        ) async {
+            var completedLoopCount = 0
+
+            while !Task.isCancelled && (
+                descriptor.loopCount == 0 ||
+                completedLoopCount < descriptor.loopCount
+            ) {
+                for index in 0..<descriptor.frameCount {
+                    guard
+                        !Task.isCancelled,
+                        let imageView,
+                        let frame = await AnimatedImagePipeline.shared.frame(
+                            at: index,
+                            for: data
+                        )
+                    else {
+                        return
+                    }
+
+                    imageView.image = UIImage(
+                        cgImage: frame.image,
+                        scale: max(scale, 1),
+                        orientation: .up
+                    )
+
+                    do {
+                        try await Task.sleep(
+                            for: .seconds(descriptor.frameDelays[index])
+                        )
+                    } catch {
+                        return
+                    }
+                }
+
+                completedLoopCount += 1
+            }
+        }
     }
 }
 
-private enum AnimatedUIImageDecoder {
-    static func image(
-        from data: Data,
-        animates: Bool,
-        scale: CGFloat
-    ) -> UIImage? {
+private struct AnimatedImageDescriptor: Sendable {
+    let frameCount: Int
+    let frameDelays: [TimeInterval]
+    let loopCount: Int
+    let canAnimate: Bool
+}
+
+private final class SendableCGImage: @unchecked Sendable {
+    let image: CGImage
+
+    init(_ image: CGImage) {
+        self.image = image
+    }
+}
+
+private actor AnimatedImagePipeline {
+    static let shared = AnimatedImagePipeline()
+
+    private struct SourceEntry {
+        let source: CGImageSource
+        let descriptor: AnimatedImageDescriptor
+        let cost: Int
+        var accessOrder: UInt64
+    }
+
+    private struct FrameKey: Hashable, Sendable {
+        let data: Data
+        let index: Int
+    }
+
+    private struct FrameEntry {
+        let frame: SendableCGImage
+        let cost: Int
+        var accessOrder: UInt64
+    }
+
+    // CloudKit upload validation permits up to 10 MB of encoded image data. The
+    // source cache is intentionally only large enough for one worst-case asset
+    // plus a few normal spinner GIFs.
+    private let maximumCacheableEncodedBytes = 10 * 1_024 * 1_024
+    private let encodedCacheCostLimit = 16 * 1_024 * 1_024
+
+    // Frames are decoded lazily, downsampled, and retained in an explicit LRU.
+    // No view ever constructs an unbounded UIImage frame array.
+    private let maximumFrameCount = 300
+    private let maximumFramePixelDimension = 1_024
+    private let maximumDecodedFrameCost = 8 * 1_024 * 1_024
+    private let decodedCacheCostLimit = 24 * 1_024 * 1_024
+
+    private var sources: [Data: SourceEntry] = [:]
+    private var frames: [FrameKey: FrameEntry] = [:]
+    private var encodedCacheCost = 0
+    private var decodedCacheCost = 0
+    private var accessOrder: UInt64 = 0
+
+    func descriptor(for data: Data) -> AnimatedImageDescriptor? {
+        sourceEntry(for: data)?.descriptor
+    }
+
+    func frame(at index: Int, for data: Data) -> SendableCGImage? {
+        let key = FrameKey(data: data, index: index)
+        accessOrder &+= 1
+
+        if var cached = frames[key] {
+            cached.accessOrder = accessOrder
+            frames[key] = cached
+            return cached.frame
+        }
+
         guard
+            let sourceEntry = sourceEntry(for: data),
+            index >= 0,
+            index < sourceEntry.descriptor.frameCount
+        else {
+            return nil
+        }
+
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maximumFramePixelDimension,
+            kCGImageSourceShouldCacheImmediately: true
+        ]
+
+        guard let image = CGImageSourceCreateThumbnailAtIndex(
+            sourceEntry.source,
+            index,
+            options as CFDictionary
+        ) else {
+            return nil
+        }
+
+        let cost = image.bytesPerRow * image.height
+        guard cost <= maximumDecodedFrameCost else {
+            return nil
+        }
+
+        let frame = SendableCGImage(image)
+        guard data.count <= maximumCacheableEncodedBytes else {
+            return frame
+        }
+
+        frames[key] = FrameEntry(
+            frame: frame,
+            cost: cost,
+            accessOrder: accessOrder
+        )
+        decodedCacheCost += cost
+        trimFrameCache()
+        return frame
+    }
+
+    private func sourceEntry(for data: Data) -> SourceEntry? {
+        accessOrder &+= 1
+
+        if var cached = sources[data] {
+            cached.accessOrder = accessOrder
+            sources[data] = cached
+            return cached
+        }
+
+        guard
+            !data.isEmpty,
             let source = CGImageSourceCreateWithData(data as CFData, nil),
             CGImageSourceGetCount(source) > 0
         else {
             return nil
         }
 
-        let frameCount = CGImageSourceGetCount(source)
-        guard animates, frameCount > 1 else {
-            guard let frame = CGImageSourceCreateImageAtIndex(source, 0, nil) else {
-                return UIImage(data: data)
-            }
-            return UIImage(
-                cgImage: frame,
-                scale: scale,
-                orientation: .up
-            )
+        let descriptor = makeDescriptor(for: source)
+        let entry = SourceEntry(
+            source: source,
+            descriptor: descriptor,
+            cost: data.count,
+            accessOrder: accessOrder
+        )
+
+        guard data.count <= maximumCacheableEncodedBytes else {
+            return entry
         }
 
-        var frames: [UIImage] = []
-        var totalDuration: TimeInterval = 0
-        frames.reserveCapacity(frameCount)
-
-        for index in 0..<frameCount {
-            guard let frame = CGImageSourceCreateImageAtIndex(source, index, nil) else {
-                continue
-            }
-
-            frames.append(
-                UIImage(
-                    cgImage: frame,
-                    scale: scale,
-                    orientation: .up
-                )
-            )
-            totalDuration += frameDuration(at: index, in: source)
-        }
-
-        guard !frames.isEmpty else { return nil }
-        guard frames.count > 1 else { return frames[0] }
-
-        return UIImage.animatedImage(
-            with: frames,
-            duration: max(totalDuration, 0.1)
-        ) ?? frames[0]
+        sources[data] = entry
+        encodedCacheCost += entry.cost
+        trimSourceCache(protecting: data)
+        return entry
     }
 
-    private static func frameDuration(
+    private func makeDescriptor(
+        for source: CGImageSource
+    ) -> AnimatedImageDescriptor {
+        let sourceFrameCount = CGImageSourceGetCount(source)
+        let isAnimatedGIF: Bool
+        if let typeIdentifier = CGImageSourceGetType(source) {
+            isAnimatedGIF = UTType(typeIdentifier as String) == .gif &&
+                sourceFrameCount > 1
+        } else {
+            isAnimatedGIF = false
+        }
+        let canAnimate = isAnimatedGIF &&
+            sourceFrameCount <= maximumFrameCount
+
+        let frameCount = isAnimatedGIF ? sourceFrameCount : 1
+        let delays = canAnimate
+            ? (0..<frameCount).map { frameDuration(at: $0, in: source) }
+            : []
+
+        return AnimatedImageDescriptor(
+            frameCount: frameCount,
+            frameDelays: delays,
+            loopCount: canAnimate ? loopCount(in: source) : 1,
+            canAnimate: canAnimate
+        )
+    }
+
+    private func frameDuration(
         at index: Int,
         in source: CGImageSource
     ) -> TimeInterval {
@@ -154,6 +404,106 @@ private enum AnimatedUIImageDecoder {
         ] as? NSNumber
         let duration = unclamped?.doubleValue ?? clamped?.doubleValue ?? 0.1
 
-        return duration < 0.02 ? 0.1 : duration
+        guard duration.isFinite, duration > 0 else {
+            return 0.1
+        }
+
+        // Avoid pathological zero-delay busy loops while retaining each frame's
+        // distinct source timing.
+        return min(max(duration, 0.02), 60)
+    }
+
+    private func loopCount(in source: CGImageSource) -> Int {
+        guard
+            let properties = CGImageSourceCopyProperties(
+                source,
+                nil
+            ) as? [CFString: Any],
+            let gifProperties = properties[
+                kCGImagePropertyGIFDictionary
+            ] as? [CFString: Any],
+            let count = gifProperties[
+                kCGImagePropertyGIFLoopCount
+            ] as? NSNumber
+        else {
+            return 0
+        }
+
+        return max(count.intValue, 0)
+    }
+
+    private func trimSourceCache(protecting protectedData: Data) {
+        while encodedCacheCost > encodedCacheCostLimit {
+            guard let victim = sources
+                .filter({ $0.key != protectedData })
+                .min(by: { $0.value.accessOrder < $1.value.accessOrder })
+            else {
+                break
+            }
+
+            if let removed = sources.removeValue(forKey: victim.key) {
+                encodedCacheCost -= removed.cost
+                removeFrames(for: victim.key)
+            }
+        }
+    }
+
+    private func trimFrameCache() {
+        while decodedCacheCost > decodedCacheCostLimit,
+              let victim = frames.min(
+                by: { $0.value.accessOrder < $1.value.accessOrder }
+              ) {
+            if let removed = frames.removeValue(forKey: victim.key) {
+                decodedCacheCost -= removed.cost
+            }
+        }
+    }
+
+    private func removeFrames(for data: Data) {
+        let matchingKeys = frames.keys.filter { $0.data == data }
+        for key in matchingKeys {
+            if let removed = frames.removeValue(forKey: key) {
+                decodedCacheCost -= removed.cost
+            }
+        }
     }
 }
+#elseif canImport(AppKit)
+private struct PlatformAnimatedImageView: NSViewRepresentable {
+    let data: Data
+    let animates: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> NSImageView {
+        let imageView = NSImageView()
+        imageView.imageAlignment = .alignCenter
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.animates = animates
+        imageView.wantsLayer = true
+        imageView.layer?.magnificationFilter = .nearest
+        return imageView
+    }
+
+    func updateNSView(_ imageView: NSImageView, context: Context) {
+        guard
+            context.coordinator.data != data ||
+            context.coordinator.animates != animates
+        else {
+            return
+        }
+
+        context.coordinator.data = data
+        context.coordinator.animates = animates
+        imageView.animates = animates
+        imageView.image = NSImage(data: data)
+    }
+
+    final class Coordinator {
+        var data: Data?
+        var animates = false
+    }
+}
+#endif

--- a/Craftify/AnimatedImageView.swift
+++ b/Craftify/AnimatedImageView.swift
@@ -215,7 +215,7 @@ private struct AnimatedImageDescriptor: Sendable {
 private final class SendableCGImage: @unchecked Sendable {
     let image: CGImage
 
-    init(_ image: CGImage) {
+    nonisolated init(_ image: CGImage) {
         self.image = image
     }
 }

--- a/Craftify/AnimatedImageView.swift
+++ b/Craftify/AnimatedImageView.swift
@@ -65,7 +65,8 @@ private struct AnimatedUIImageView: UIViewRepresentable {
         context.coordinator.animates = animates
         imageView.image = AnimatedUIImageDecoder.image(
             from: data,
-            animates: animates
+            animates: animates,
+            scale: context.environment.displayScale
         )
     }
 
@@ -76,7 +77,11 @@ private struct AnimatedUIImageView: UIViewRepresentable {
 }
 
 private enum AnimatedUIImageDecoder {
-    static func image(from data: Data, animates: Bool) -> UIImage? {
+    static func image(
+        from data: Data,
+        animates: Bool,
+        scale: CGFloat
+    ) -> UIImage? {
         guard
             let source = CGImageSourceCreateWithData(data as CFData, nil),
             CGImageSourceGetCount(source) > 0
@@ -91,7 +96,7 @@ private enum AnimatedUIImageDecoder {
             }
             return UIImage(
                 cgImage: frame,
-                scale: UIScreen.main.scale,
+                scale: scale,
                 orientation: .up
             )
         }
@@ -108,7 +113,7 @@ private enum AnimatedUIImageDecoder {
             frames.append(
                 UIImage(
                     cgImage: frame,
-                    scale: UIScreen.main.scale,
+                    scale: scale,
                     orientation: .up
                 )
             )

--- a/Craftify/CraftImageStore.swift
+++ b/Craftify/CraftImageStore.swift
@@ -35,7 +35,7 @@ final class CraftImageStore: ObservableObject {
     private let defaults: UserDefaults
     private let imageDirectory: URL
     private let legacyCacheDirectory: URL
-    private let imageCache = NSCache<NSString, UIImage>()
+    private let dataCache = NSCache<NSString, NSData>()
     private var loadingKeys: Set<String> = []
     private var lastChecked: [String: Date] = [:]
     private var storageGeneration = 0
@@ -67,21 +67,29 @@ final class CraftImageStore: ObservableObject {
             .appendingPathComponent("CraftImageAssets", isDirectory: true)
 
         prepareStorage()
-        imageCache.countLimit = 300
+        dataCache.countLimit = 300
+        dataCache.totalCostLimit = 64 * 1_024 * 1_024
     }
 
-    func image(for assetKey: String) -> UIImage? {
+    func imageData(for assetKey: String) -> Data? {
         let cacheKey = assetKey as NSString
-        if let image = imageCache.object(forKey: cacheKey) {
-            return image
+        if let cachedData = dataCache.object(forKey: cacheKey) {
+            return cachedData as Data
         }
 
-        if let image = UIImage(contentsOfFile: cachedFileURL(for: assetKey).path) {
-            imageCache.setObject(image, forKey: cacheKey)
-            return image
+        guard
+            let data = try? Data(contentsOf: cachedFileURL(for: assetKey)),
+            CraftImageData.isValidImage(data)
+        else {
+            return nil
         }
 
-        return UIImage(named: assetKey)
+        dataCache.setObject(
+            data as NSData,
+            forKey: cacheKey,
+            cost: data.count
+        )
+        return data
     }
 
     func prefetch(recipes: [Recipe]) {
@@ -246,7 +254,7 @@ final class CraftImageStore: ObservableObject {
             }
 
             let outdatedKeys = metadata.compactMap { key, remoteVersion -> String? in
-                let hasValidFile = UIImage(contentsOfFile: cachedFileURL(for: key).path) != nil
+                let hasValidFile = imageData(for: key) != nil
                 return localVersion(for: key) < remoteVersion || !hasValidFile ? key : nil
             }
 
@@ -334,12 +342,16 @@ final class CraftImageStore: ObservableObject {
         }
 
         let data = try Data(contentsOf: sourceURL)
-        guard let image = UIImage(data: data) else {
+        guard CraftImageData.isValidImage(data) else {
             throw CraftImageStoreError.invalidImageData
         }
 
         try data.write(to: cachedFileURL(for: assetKey), options: .atomic)
-        imageCache.setObject(image, forKey: assetKey as NSString)
+        dataCache.setObject(
+            data as NSData,
+            forKey: assetKey as NSString,
+            cost: data.count
+        )
 
         let version = record[CraftImageAssetKey.versionField] as? Int64 ?? 1
         defaults.set(Int(version), forKey: versionDefaultsKey(for: assetKey))
@@ -365,7 +377,7 @@ final class CraftImageStore: ObservableObject {
         storageGeneration += 1
         loadingKeys.removeAll()
         lastChecked.removeAll()
-        imageCache.removeAllObjects()
+        dataCache.removeAllObjects()
 
         defaults.dictionaryRepresentation().keys
             .filter { $0.hasPrefix(Self.versionDefaultsPrefix) }
@@ -452,7 +464,7 @@ final class CraftImageStore: ObservableObject {
 
     private func removeCachedRemoteImage(for assetKey: String) {
         try? fileManager.removeItem(at: cachedFileURL(for: assetKey))
-        imageCache.removeObject(forKey: assetKey as NSString)
+        dataCache.removeObject(forKey: assetKey as NSString)
         defaults.removeObject(forKey: versionDefaultsKey(for: assetKey))
     }
 }
@@ -483,8 +495,10 @@ struct CraftImage: View {
 
     var body: some View {
         Group {
-            if let image = store.image(for: key) {
-                Image(uiImage: image)
+            if let data = store.imageData(for: key) {
+                AnimatedImageView(data: data)
+            } else if let bundledImage = UIImage(named: key) {
+                Image(uiImage: bundledImage)
                     .resizable()
                     .interpolation(.none)
             } else {

--- a/CraftifyUITests/CraftifyUITests.swift
+++ b/CraftifyUITests/CraftifyUITests.swift
@@ -5,34 +5,48 @@
 //  Created by Dave Van Cauwenberghe on 07/02/2025.
 //
 
-import Testing
 import XCTest
-@testable import Craftify
 
-struct CraftifyUITests {
+final class CraftifyUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
     @MainActor
-    @Test func testTextSizePickerInContentView() throws {
-        // Launch the app
+    func testTextSizePickerInContentView() throws {
         let app = XCUIApplication()
         app.launch()
-        
-        // Navigate to App Appearance (assumes "More" tab in ContentView)
-        #expect(app.tabBars.buttons["More"].exists, "More tab should exist")
-        app.tabBars.buttons["More"].tap()
-        
-        // Navigate to App Appearance view
-        #expect(app.tables.cells.staticTexts["App Appearance"].exists, "App Appearance cell should exist")
-        app.tables.cells.staticTexts["App Appearance"].tap()
-        
-        // Enable Custom Text Size toggle
-        #expect(app.tables.cells.switches["Custom Text Size"].exists, "Custom Text Size toggle should exist")
-        app.tables.cells.switches["Custom Text Size"].tap()
-        
-        // Verify scroll picker appears
-        #expect(app.pickers["Text Size Picker"].exists, "Text Size Picker should be visible")
-        
-        // Select Extra Large
-        app.pickers["Text Size Picker"].pickerWheels.element.adjust(toPickerWheelValue: "Extra Large")
-        #expect(app.pickers["Text Size Picker"].pickerWheels.element.value as? String == "Extra Large", "Picker should select Extra Large")
+
+        let moreTab = app.tabBars.buttons["More"]
+        XCTAssertTrue(moreTab.waitForExistence(timeout: 5), "More tab should exist")
+        moreTab.tap()
+
+        let appearanceCell = app.tables.cells.staticTexts["App Appearance"]
+        XCTAssertTrue(
+            appearanceCell.waitForExistence(timeout: 5),
+            "App Appearance cell should exist"
+        )
+        appearanceCell.tap()
+
+        let textSizeToggle = app.tables.cells.switches["Custom Text Size"]
+        XCTAssertTrue(
+            textSizeToggle.waitForExistence(timeout: 5),
+            "Custom Text Size toggle should exist"
+        )
+        textSizeToggle.tap()
+
+        let textSizePicker = app.pickers["Text Size Picker"]
+        XCTAssertTrue(
+            textSizePicker.waitForExistence(timeout: 5),
+            "Text Size Picker should be visible"
+        )
+
+        let pickerWheel = textSizePicker.pickerWheels.element
+        pickerWheel.adjust(toPickerWheelValue: "Extra Large")
+        XCTAssertEqual(
+            pickerWheel.value as? String,
+            "Extra Large",
+            "Picker should select Extra Large"
+        )
     }
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Craftify is a sleek iOS app designed for Minecraft players to browse, search, an
 - **Accessibility**: Fully optimized for VoiceOver, Dynamic Type, and other iOS accessibility features.
 - **Light/Dark Mode**: Seamlessly adapts to your device’s appearance settings.
 - **CloudKit Syncing**: Keep your favorites in sync across all your devices.
+- **Cloud Image Library**: Download and display PNG and animated GIF recipe artwork.
 - **Haptic Feedback**: Enjoy tactile feedback for a more engaging experience.
 
 #### Disclaimer


### PR DESCRIPTION
## Summary

- preserve original CloudKit image bytes in the persistent and memory-bounded caches
- render animated GIF artwork through a shared, off-main ImageIO pipeline
- preserve every GIF frame's individual delay and the source loop count
- lazily downsample frames to at most 1024 pixels and cap animation at 300 frames
- bound encoded-source caching to 16 MB and decoded-frame caching to 24 MB
- cancel rendering when a SwiftUI/UIKit view is reused or dismantled
- retain PNG and bundled-image fallbacks
- honor Reduce Motion by displaying the first frame instead of animating

## CI maintenance

- run the project with Xcode 26 on `macos-26`, which supports project format 100
- make xcodebuild failures fail the workflow instead of being hidden by a shell pipe
- select an available iOS simulator dynamically
- replace the UI-test target's incompatible Swift Testing import with XCTest
- update GitHub actions to Node 24-based releases

## Validation

- [x] Craftify builds for an iOS 26 Simulator with an iOS 18 deployment target
- [x] Craftify unit tests pass
- [x] code coverage report uploads
- [x] Swift 6 accepts the bounded off-main GIF renderer

Validated by [Craftify iOS CI run #187](https://github.com/davevancauwenberghe/Craftify/actions/runs/30947532173) using Xcode 26.6. The remaining warnings are the pre-existing `LaunchScreen.imageset` references and an unrelated unused test variable.

No third-party image dependency is introduced.