### PR TITLE
Create a cohesive adaptive Craftify interface

### DIFF
--- a/Craftify/AppAppearanceView.swift
+++ b/Craftify/AppAppearanceView.swift
@@ -21,19 +21,15 @@ struct AccentColorOption: Identifiable {
 }
 
 struct AppAppearanceView: View {
-    @EnvironmentObject var dataManager: DataManager
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @AppStorage("selectedAppIcon") private var selectedAppIcon: String?
-    @AppStorage("colorSchemePreference") private var colorSchemePreference: String = "system"
-    @AppStorage("accentColorPreference") private var accentColorPreference: String = "default"
+    @AppStorage("colorSchemePreference") private var colorSchemePreference = "system"
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
+
     @State private var errorMessage: String?
     @State private var supportsAlternateIcons = UIApplication.shared.supportsAlternateIcons
     @State private var isChangingIcon = false
-    @ScaledMetric(relativeTo: .body) private var iconSize: CGFloat = 44
-    @ScaledMetric(relativeTo: .body) private var swatchSize: CGFloat = 20
-    @ScaledMetric(relativeTo: .body) private var paddingVertical: CGFloat = 8
-    @ScaledMetric(relativeTo: .body) private var spacing: CGFloat = 12
 
     private let appIcons: [AppIcon] = [
         .init(id: nil, name: "Craftify", previewName: "AppIconPreview"),
@@ -62,133 +58,246 @@ struct AppAppearanceView: View {
             ?? Self.accentColors[0].color
     }
 
-    var body: some View {
-        List {
-            Section(header: Text("Appearance")) {
-                Picker("Appearance", selection: $colorSchemePreference) {
-                    Text("System").tag("system")
-                    Text("Light").tag("light")
-                    Text("Dark").tag("dark")
-                }
-                .pickerStyle(.segmented)
-                .accessibilityLabel("Appearance")
-                .accessibilityHint("Choose between System, Light, or Dark mode")
-                .onChange(of: colorSchemePreference) { _, _ in HapticFeedback.selection() }
-            }
-            
-            Section(header: Text("Accent Color")) {
-                Picker("Accent Color", selection: $accentColorPreference) {
-                    ForEach(Self.accentColors) { option in
-                        HStack {
-                            Circle()
-                                .fill(option.color)
-                                .frame(width: swatchSize, height: swatchSize)
-                                .accessibilityLabel("\(option.name) color swatch")
-                            Text(option.name)
-                                .font(.body)
-                        }
-                        .tag(option.id)
-                    }
-                }
-                .id(accentColorPreference)
-                .accessibilityLabel("Accent Color")
-                .accessibilityHint("Choose the accent color for the app")
-                .onChange(of: accentColorPreference) { _, _ in HapticFeedback.selection() }
-            }
-            
-            Section(header: Text("App Icons")) {
-                if supportsAlternateIcons {
-                    ForEach(appIcons) { icon in
-                        Button {
-                            changeIcon(to: icon.id)
-                        } label: {
-                            HStack(spacing: spacing) {
-                                if let uiImage = UIImage(named: icon.previewName) {
-                                    Image(uiImage: uiImage)
-                                        .resizable()
-                                        .scaledToFit()
-                                        .frame(width: iconSize, height: iconSize)
-                                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                                } else {
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .fill(Color.secondary.opacity(0.2))
-                                        .frame(width: iconSize, height: iconSize)
-                                }
-
-                                Text(icon.name)
-                                    .font(.headline)
-                                    .minimumScaleFactor(0.8)
-                                    .foregroundColor(selectedAccentColor)
-                                Spacer()
-                                if selectedAppIcon == icon.id {
-                                    Image(systemName: "checkmark.circle.fill")
-                                        .imageScale(.large)
-                                        .foregroundColor(selectedAccentColor)
-                                }
-                            }
-                            .padding(.vertical, horizontalSizeClass == .regular ? paddingVertical * 1.5 : paddingVertical)
-                        }
-                        .accessibilityLabel("Select \(icon.name) icon")
-                        .accessibilityHint(selectedAppIcon == icon.id ? "Currently selected" : "Double tap to select this icon")
-                        .accessibilityAddTraits(.isButton)
-                        .disabled(isChangingIcon || selectedAppIcon == icon.id)
-                    }
-                } else {
-                    Text("Alternate icons aren’t available yet.")
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                        .minimumScaleFactor(0.8)
-                        .padding(.vertical, horizontalSizeClass == .regular ? paddingVertical * 1.5 : paddingVertical)
-                        .accessibilityLabel("Alternate icons not available")
-                        .accessibilityHint("Check back later for new icon options")
-                }
-            }
-        }
-        .listStyle(.insetGrouped)
-        .scrollContentBackground(.hidden)
-        .background(Color(.systemGroupedBackground))
-        .navigationTitle("App Appearance")
-        .navigationBarTitleDisplayMode(.large)
-        .tint(selectedAccentColor)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-        .safeAreaInset(edge: .top, content: { Color.clear.frame(height: 0) })
-        .safeAreaInset(edge: .bottom, content: { Color.clear.frame(height: 0) })
-        .alert("Error",
-               isPresented: Binding(
-                   get: { errorMessage != nil },
-                   set: { if !$0 { errorMessage = nil } }
-               ),
-               actions: { Button("OK", role: .cancel) {} },
-               message: { Text(errorMessage ?? "An unknown error occurred") }
+    private var accentColumns: [GridItem] {
+        CraftifyLayout.adaptiveColumns(
+            minimum: dynamicTypeSize.isAccessibilitySize ? 260 : 128,
+            maximum: 220,
+            spacing: 10,
+            dynamicTypeSize: dynamicTypeSize
         )
-        .onAppear {
-            selectedAppIcon = UIApplication.shared.alternateIconName
-        }
-        .onChange(of: dataManager.isLoading) { _, newValue in
-            if !newValue && dataManager.isManualSyncing {
-                // Placeholder for future DataManager dependencies
-            }
-        }
-        .preferredColorScheme(
-            colorSchemePreference == "system" ? nil :
-            (colorSchemePreference == "light" ? .light : .dark)
-        )
-        .dynamicTypeSize(.xSmall ... .accessibility5)
     }
 
-    private func changeIcon(to: String?) {
-        guard !isChangingIcon, UIApplication.shared.alternateIconName != to else { return }
+    private var iconColumns: [GridItem] {
+        CraftifyLayout.adaptiveColumns(
+            minimum: dynamicTypeSize.isAccessibilitySize ? 280 : 190,
+            maximum: 280,
+            spacing: 14,
+            dynamicTypeSize: dynamicTypeSize
+        )
+    }
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 24) {
+                CraftifyHero(
+                    eyebrow: "Your Craftify",
+                    title: "Make It Feel Like Yours",
+                    detail: "Choose an appearance, accent, and app icon. Every option keeps the same accessible Craftify experience.",
+                    symbol: "paintpalette.fill"
+                )
+
+                appearanceSection
+                accentSection
+                appIconSection
+            }
+            .craftifyContentWidth(CraftifyLayout.formMaxWidth)
+            .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+            .padding(.top, 12)
+            .padding(.bottom, 32)
+        }
+        .navigationTitle("App Appearance")
+        .navigationBarTitleDisplayMode(.large)
+        .craftifyPage()
+        .alert("Couldn’t Change App Icon", isPresented: errorBinding) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "An unknown error occurred.")
+        }
+        .onAppear { selectedAppIcon = UIApplication.shared.alternateIconName }
+        .preferredColorScheme(preferredColorScheme)
+    }
+
+    private var appearanceSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            CraftifySectionHeader(
+                title: "Appearance",
+                detail: "Follow the device or choose a permanent light or dark canvas.",
+                symbol: "circle.lefthalf.filled"
+            )
+
+            Picker("Appearance", selection: $colorSchemePreference) {
+                Label("System", systemImage: "iphone").tag("system")
+                Label("Light", systemImage: "sun.max.fill").tag("light")
+                Label("Dark", systemImage: "moon.fill").tag("dark")
+            }
+            .pickerStyle(.segmented)
+            .onChange(of: colorSchemePreference) { _, _ in HapticFeedback.selection() }
+            .accessibilityHint("Choose System, Light, or Dark appearance")
+        }
+        .padding(18)
+        .craftifyCard(cornerRadius: 22)
+    }
+
+    private var accentSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            CraftifySectionHeader(
+                title: "Accent Color",
+                detail: "Your selection colors controls, crafting highlights, and the Craftify atmosphere.",
+                symbol: "paintbrush.pointed.fill"
+            )
+
+            LazyVGrid(columns: accentColumns, spacing: 10) {
+                ForEach(Self.accentColors) { option in
+                    accentButton(option)
+                }
+            }
+        }
+        .padding(18)
+        .craftifyCard(cornerRadius: 22)
+    }
+
+    private func accentButton(_ option: AccentColorOption) -> some View {
+        let isSelected = accentColorPreference == option.id
+
+        return Button {
+            accentColorPreference = option.id
+            HapticFeedback.selection()
+        } label: {
+            HStack(spacing: 10) {
+                Circle()
+                    .fill(option.color.gradient)
+                    .frame(width: 30, height: 30)
+                    .overlay {
+                        Circle().stroke(Color.primary.opacity(0.12), lineWidth: 1)
+                    }
+                    .accessibilityHidden(true)
+                Text(option.name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Spacer(minLength: 2)
+                if isSelected {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(option.color)
+                        .accessibilityHidden(true)
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(minHeight: 52)
+            .background(
+                option.color.opacity(isSelected ? 0.14 : 0.045),
+                in: RoundedRectangle(cornerRadius: 14, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(option.color.opacity(isSelected ? 0.60 : 0.15), lineWidth: isSelected ? 2 : 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(option.name)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+    }
+
+    private var appIconSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            CraftifySectionHeader(
+                title: "App Icon",
+                detail: "Pick the Craftify mark you want to see on your Home Screen.",
+                symbol: "app.fill"
+            )
+
+            if supportsAlternateIcons {
+                LazyVGrid(columns: iconColumns, spacing: 14) {
+                    ForEach(appIcons) { icon in
+                        appIconButton(icon)
+                    }
+                }
+            } else {
+                Label("Alternate icons aren’t available on this device.", systemImage: "info.circle")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .padding(.vertical, 8)
+            }
+        }
+        .padding(18)
+        .craftifyCard(cornerRadius: 22)
+    }
+
+    private func appIconButton(_ icon: AppIcon) -> some View {
+        let isSelected = selectedAppIcon == icon.id
+
+        return Button {
+            changeIcon(to: icon.id)
+        } label: {
+            HStack(spacing: 14) {
+                Group {
+                    if let image = UIImage(named: icon.previewName) {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFit()
+                    } else {
+                        Image(systemName: "app.dashed")
+                            .resizable()
+                            .scaledToFit()
+                            .padding(14)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(width: 64, height: 64)
+                .background(Color.primary.opacity(0.04))
+                .clipShape(RoundedRectangle(cornerRadius: 15, style: .continuous))
+                .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(icon.name)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text(isSelected ? "Current icon" : "Tap to select")
+                        .font(.caption)
+                        .foregroundStyle(isSelected ? selectedAccentColor : Color.secondary)
+                }
+                Spacer(minLength: 3)
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(isSelected ? selectedAccentColor : Color.secondary)
+                    .accessibilityHidden(true)
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
+            .background(
+                selectedAccentColor.opacity(isSelected ? 0.10 : 0.03),
+                in: RoundedRectangle(cornerRadius: 17, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 17, style: .continuous)
+                    .stroke(selectedAccentColor.opacity(isSelected ? 0.48 : 0.12), lineWidth: isSelected ? 2 : 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(isChangingIcon || isSelected)
+        .accessibilityLabel(icon.name)
+        .accessibilityValue(isSelected ? "Current icon" : "Not selected")
+        .accessibilityHint(isSelected ? "" : "Changes Craftify’s Home Screen icon")
+    }
+
+    private var preferredColorScheme: ColorScheme? {
+        switch colorSchemePreference {
+        case "light": .light
+        case "dark": .dark
+        default: nil
+        }
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )
+    }
+
+    private func changeIcon(to name: String?) {
+        guard !isChangingIcon, UIApplication.shared.alternateIconName != name else { return }
         isChangingIcon = true
-        UIApplication.shared.setAlternateIconName(to) { error in
+        UIApplication.shared.setAlternateIconName(name) { error in
             DispatchQueue.main.async {
                 isChangingIcon = false
-                if let err = error {
+                if let error {
                     HapticFeedback.notification(.error)
-                    errorMessage = "Failed to change icon: \(err.localizedDescription)"
+                    errorMessage = error.localizedDescription
                 } else {
                     HapticFeedback.notification(.success)
-                    selectedAppIcon = to
-                    UIAccessibility.post(notification: .announcement, argument: "App icon changed to \(appIcons.first(where: { $0.id == to })?.name ?? "Default")")
+                    selectedAppIcon = name
+                    let displayName = appIcons.first(where: { $0.id == name })?.name ?? "Craftify"
+                    UIAccessibility.post(notification: .announcement, argument: "App icon changed to \(displayName)")
                 }
             }
         }

--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -21,21 +21,51 @@ struct ChestsView: View {
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            Group {
+            ZStack {
+                AppBackground().ignoresSafeArea()
+
                 if dataManager.chests.isEmpty {
-                    ContentUnavailableView {
-                        Label("Your Chest Room Is Empty", systemImage: "shippingbox")
-                    } description: {
-                        Text("Create a chest, then fill its slots with recipes you want to craft.")
-                    } actions: {
-                        Button("Create a Chest") {
-                            HapticFeedback.impact()
-                            editor = .new
-                        }
+                    ScrollView {
+                        VStack(spacing: 24) {
+                            CraftifyHero(
+                                eyebrow: "Project Planning",
+                                title: "Build Your Chest Room",
+                                detail: "Collect recipes in Minecraft-sized chests and keep every build organized across your devices.",
+                                symbol: "shippingbox.fill"
+                            )
+
+                            CraftifyEmptyState(
+                                symbol: "shippingbox",
+                                title: "Your Chest Room Is Empty",
+                                detail: "Create a chest, then open any recipe and use the add button to fill its slots."
+                            )
+
+                            Button("Create a Chest", systemImage: "plus") {
+                                HapticFeedback.impact()
+                                editor = .new
+                            }
                             .buttonStyle(.borderedProminent)
+                            .controlSize(.large)
+                        }
+                        .craftifyContentWidth(CraftifyLayout.formMaxWidth)
+                        .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+                        .padding(.top, 12)
+                        .padding(.bottom, 32)
                     }
                 } else {
                     List {
+                        Section {
+                            CraftifyHero(
+                                eyebrow: "Project Planning",
+                                title: "Your Chest Room",
+                                detail: "\(dataManager.chests.count) synced chest\(dataManager.chests.count == 1 ? "" : "s") ready for your next build.",
+                                symbol: "shippingbox.fill"
+                            )
+                            .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 12, trailing: 0))
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                        }
+
                         Section {
                             ForEach(dataManager.chests) { chest in
                                 ChestListRow(
@@ -44,6 +74,9 @@ struct ChestsView: View {
                                     onEdit: { editor = .edit(chest) },
                                     onDelete: { chestPendingDeletion = chest }
                                 )
+                                .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
+                                .listRowBackground(Color.clear)
+                                .listRowSeparator(.hidden)
                             }
                             .onMove(perform: dataManager.moveChests)
                             .onDelete { offsets in
@@ -53,10 +86,12 @@ struct ChestsView: View {
                             }
                         }
                     }
-                    .listStyle(.insetGrouped)
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                    .frame(maxWidth: 900)
+                    .safeAreaPadding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
                 }
             }
-            .background(Color(.systemGroupedBackground))
             .id(accentColorPreference)
             .tint(Color.userAccentColor)
             .navigationTitle("Chests")
@@ -106,6 +141,7 @@ struct ChestsView: View {
             }
             .animation(reduceMotion ? nil : .snappy, value: dataManager.chests)
             .environment(\.editMode, $editMode)
+            .craftifyNavigationBar()
         }
     }
 
@@ -166,6 +202,9 @@ private struct ChestListRow: View {
 
     var body: some View {
         rowContent
+            .padding(14)
+            .craftifyCard(cornerRadius: 20)
+            .contentShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
             .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                 Button("Delete", role: .destructive, action: onDelete)
                     .tint(.red)
@@ -212,7 +251,6 @@ private struct ChestRow: View {
                     .tint(Color.userAccentColor)
             }
         }
-        .padding(.vertical, 5)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(chest.name), \(chest.size.title), \(chest.recipeIDs.count) of \(chest.size.rawValue) slots used")
         .accessibilityHint("Opens the chest")
@@ -256,12 +294,13 @@ struct ChestDetailView: View {
                             isEditing: editMode.isEditing,
                             name: $chestName
                         )
+                        .craftifyCard(cornerRadius: 26)
                         if storedRecipes.isEmpty {
-                            ContentUnavailableView {
-                                Label("No Stored Recipes", systemImage: "square.grid.3x3")
-                            } description: {
-                                Text("Open a recipe and use the add button to store it in this chest.")
-                            }
+                            CraftifyEmptyState(
+                                symbol: "square.grid.3x3",
+                                title: "No Stored Recipes",
+                                detail: "Open a recipe and use the add button to store it in this chest."
+                            )
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 36)
                         } else {
@@ -327,6 +366,7 @@ struct ChestDetailView: View {
         .navigationDestination(for: Recipe.self) { recipe in
             RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
         }
+        .craftifyNavigationBar()
     }
 
     private func toggleEditMode() {
@@ -505,6 +545,8 @@ struct ChestEditorView: View {
                     }
                 }
             }
+            .scrollContentBackground(.hidden)
+            .background { AppBackground().ignoresSafeArea() }
             .navigationTitle(context.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -527,6 +569,7 @@ struct ChestEditorView: View {
             }
             .id(accentColorPreference)
             .tint(Color.userAccentColor)
+            .craftifyNavigationBar()
         }
     }
 
@@ -571,17 +614,24 @@ struct ChestsTutorialView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 24) {
-                    Label("Welcome to Chests", systemImage: "shippingbox.fill")
-                        .font(.largeTitle.bold()).foregroundStyle(Color.userAccentColor)
+                    CraftifyHero(
+                        eyebrow: "Getting Started",
+                        title: "Welcome to Chests",
+                        detail: "Turn the recipes you need into an organized plan for your next build.",
+                        symbol: "shippingbox.fill"
+                    )
                     TutorialStep(icon: "plus.circle.fill", title: "Collect recipes", text: "Tap + on a recipe and choose a chest, or create one without leaving the recipe.")
                     TutorialStep(icon: "square.grid.3x3.fill", title: "Minecraft-sized storage", text: "Small chests hold 27 recipes, large chests hold 54.")
                     TutorialStep(icon: "paintpalette.fill", title: "Make it yours", text: "Give every chest a name and a crafting-inspired symbol that fits what you store.")
                     TutorialStep(icon: "arrow.up.arrow.down", title: "Arrange safely", text: "Use Edit to drag chests into order, or tap one to change its name, size, or symbol. Swipe for Edit and a confirmed Delete.")
                     Text("Your chest room syncs through iCloud, so its order, names, and recipes follow you across devices.")
                         .font(.callout).foregroundStyle(.secondary)
-                }.padding(24)
+                }
+                .craftifyContentWidth(CraftifyLayout.readingMaxWidth)
+                .padding(24)
             }
             .toolbar { Button("Done") { dismiss() }.fontWeight(.semibold) }
+            .craftifyPage()
         }
     }
 }
@@ -590,8 +640,11 @@ private struct TutorialStep: View {
     let icon: String; let title: String; let text: String
     var body: some View {
         HStack(alignment: .top, spacing: 16) {
-            Image(systemName: icon).font(.title2).foregroundStyle(Color.userAccentColor).frame(width: 32).accessibilityHidden(true)
+            CraftifyIconTile(symbol: icon, size: 46)
             VStack(alignment: .leading, spacing: 4) { Text(title).font(.headline); Text(text).foregroundStyle(.secondary) }
-        }.accessibilityElement(children: .combine)
+        }
+        .padding(14)
+        .craftifyCard(cornerRadius: 18)
+        .accessibilityElement(children: .combine)
     }
 }

--- a/Craftify/ColorExtension.swift
+++ b/Craftify/ColorExtension.swift
@@ -58,24 +58,3 @@ extension Color {
         }
     }
 }
-
-/// The shared app surface, matching the accent-tinted background introduced
-/// by the chest detail screen.
-struct AppBackground: View {
-    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
-
-    var body: some View {
-        ZStack {
-            Color(.systemBackground)
-            LinearGradient(
-                colors: [
-                    Color.userAccentColor(for: accentColorPreference).opacity(0.20),
-                    Color.userAccentColor(for: accentColorPreference).opacity(0.03)
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-        }
-        .accessibilityHidden(true)
-    }
-}

--- a/Craftify/CommandsView.swift
+++ b/Craftify/CommandsView.swift
@@ -6,251 +6,326 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct CommandsView: View {
     @EnvironmentObject private var dataManager: DataManager
-    @AppStorage("colorSchemePreference") private var colorSchemePreference: String = "system"
-    @AppStorage("accentColorPreference") private var accentColorPreference: String = "default"
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @State private var searchText: String = ""
+    @State private var searchText = ""
     @State private var editionFilter: EditionFilter = .all
-    @ScaledMetric(relativeTo: .body) private var paddingVertical: CGFloat = 8
-    @ScaledMetric(relativeTo: .body) private var paddingHorizontal: CGFloat = 12
-    @ScaledMetric(relativeTo: .body) private var spacingLarge: CGFloat = 16
-    @ScaledMetric(relativeTo: .body) private var spacingSmall: CGFloat = 4
+    @State private var copiedCommandID: String?
 
     private enum EditionFilter: String, CaseIterable, Identifiable {
-        case all     = "All Editions"
+        case all = "All Editions"
         case bedrock = "Bedrock Edition"
-        case java    = "Java Edition"
-        var id: String { rawValue }
+        case java = "Java Edition"
+
+        var id: Self { self }
+        var symbol: String {
+            switch self {
+            case .all: "square.stack.3d.up.fill"
+            case .bedrock: "cube.fill"
+            case .java: "cup.and.heat.waves.fill"
+            }
+        }
     }
 
     private var filteredCommands: [ConsoleCommand] {
         dataManager.consoleCommands
-            .filter { cmd in
+            .filter { command in
                 switch editionFilter {
-                case .all:     return true
-                case .bedrock: return cmd.worksInBedrock
-                case .java:    return cmd.worksInJava
+                case .all: true
+                case .bedrock: command.worksInBedrock
+                case .java: command.worksInJava
                 }
             }
-            .filter { cmd in
+            .filter { command in
                 searchText.isEmpty
-                    || cmd.name.localizedCaseInsensitiveContains(searchText)
-                    || cmd.description.localizedCaseInsensitiveContains(searchText)
+                    || command.name.localizedCaseInsensitiveContains(searchText)
+                    || command.description.localizedCaseInsensitiveContains(searchText)
             }
     }
 
-    private func color(forOP level: Int64) -> Color {
-        switch level {
-        case 1: return .red
-        case 2: return .orange
-        case 3: return .yellow
-        case 4: return .green
-        default: return .gray
+    private var columns: [GridItem] {
+        CraftifyLayout.adaptiveColumns(
+            minimum: dynamicTypeSize.isAccessibilitySize ? 300 : 310,
+            maximum: 480,
+            spacing: 14,
+            dynamicTypeSize: dynamicTypeSize
+        )
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 24) {
+                    CraftifyHero(
+                        eyebrow: "Minecraft Reference",
+                        title: "Console Commands",
+                        detail: "Find commands for Bedrock and Java Edition, check operator requirements, and copy the exact command in one tap.",
+                        symbol: "terminal.fill"
+                    )
+
+                    HStack {
+                        CraftifyStatusPill(
+                            title: editionFilter.rawValue,
+                            symbol: editionFilter.symbol
+                        )
+                        Spacer()
+                        Text("\(filteredCommands.count) command\(filteredCommands.count == 1 ? "" : "s")")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if filteredCommands.isEmpty {
+                        CraftifyEmptyState(
+                            symbol: "terminal",
+                            title: "No Commands Found",
+                            detail: "Try another search term or choose a different Minecraft edition."
+                        )
+                        .frame(maxWidth: .infinity)
+                    } else {
+                        LazyVGrid(columns: columns, alignment: .leading, spacing: 14) {
+                            ForEach(filteredCommands) { command in
+                                CommandCard(
+                                    command: command,
+                                    isCopied: copiedCommandID == command.id,
+                                    onCopy: { copy(command) },
+                                    onShowOPLevels: {
+                                        withAnimation(.easeInOut) {
+                                            proxy.scrollTo("opExplanation", anchor: .top)
+                                        }
+                                    }
+                                )
+                            }
+                        }
+                    }
+
+                    OPLevelsCard()
+                        .id("opExplanation")
+                }
+                .craftifyContentWidth()
+                .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+                .padding(.top, 12)
+                .padding(.bottom, 34)
+            }
+            .refreshable { dataManager.fetchConsoleCommands() }
+            .navigationTitle("Console Commands")
+            .navigationBarTitleDisplayMode(.large)
+            .searchable(
+                text: $searchText,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "Search commands"
+            )
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        ForEach(EditionFilter.allCases) { filter in
+                            Button {
+                                editionFilter = filter
+                                HapticFeedback.selection()
+                            } label: {
+                                Label(filter.rawValue, systemImage: editionFilter == filter ? "checkmark" : filter.symbol)
+                            }
+                        }
+                    } label: {
+                        Label("Filter", systemImage: "line.3.horizontal.decrease.circle")
+                    }
+                    .accessibilityLabel("Filter commands by edition")
+                    .accessibilityValue(editionFilter.rawValue)
+                }
+            }
+            .craftifyPage()
+            .onAppear { dataManager.fetchConsoleCommands() }
+        }
+    }
+
+    private func copy(_ command: ConsoleCommand) {
+        UIPasteboard.general.string = command.name
+        copiedCommandID = command.id
+        HapticFeedback.notification(.success)
+        UIAccessibility.post(notification: .announcement, argument: "Copied \(command.name)")
+
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.5))
+            if copiedCommandID == command.id { copiedCommandID = nil }
+        }
+    }
+}
+
+private struct CommandCard: View {
+    let command: ConsoleCommand
+    let isCopied: Bool
+    let onCopy: () -> Void
+    let onShowOPLevels: () -> Void
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 15) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "chevron.left.forwardslash.chevron.right")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(Color.userAccentColor)
+                    .frame(width: 44, height: 44)
+                    .background(Color.userAccentColor.opacity(0.11), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .accessibilityHidden(true)
+
+                Text(command.name)
+                    .font(.system(.headline, design: .monospaced, weight: .bold))
+                    .foregroundStyle(.primary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Button(action: onCopy) {
+                    Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
+                        .font(.body.weight(.semibold))
+                        .frame(width: 36, height: 36)
+                }
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.circle)
+                .accessibilityLabel(isCopied ? "Command copied" : "Copy command")
+            }
+
+            Text(command.description)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 9) { editionBadges }
+                VStack(alignment: .leading, spacing: 9) { editionBadges }
+            }
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, minHeight: dynamicTypeSize.isAccessibilitySize ? nil : 190, alignment: .topLeading)
+        .craftifyCard(cornerRadius: 20)
+        .contextMenu {
+            Button("Copy Command", systemImage: "doc.on.doc", action: onCopy)
+        }
+    }
+
+    @ViewBuilder
+    private var editionBadges: some View {
+        CommandEditionBadge(
+            title: "Bedrock",
+            isSupported: command.worksInBedrock,
+            opLevel: command.opLevelBedrock,
+            onShowOPLevels: onShowOPLevels
+        )
+        CommandEditionBadge(
+            title: "Java",
+            isSupported: command.worksInJava,
+            opLevel: command.opLevelJava,
+            onShowOPLevels: onShowOPLevels
+        )
+    }
+}
+
+private struct CommandEditionBadge: View {
+    let title: String
+    let isSupported: Bool
+    let opLevel: Int64?
+    let onShowOPLevels: () -> Void
+
+    private var opColor: Color {
+        switch opLevel {
+        case 1: .red
+        case 2: .orange
+        case 3: .yellow
+        case 4: .green
+        default: .gray
         }
     }
 
     var body: some View {
-        NavigationStack {
-            ScrollViewReader { proxy in
-                List {
-                    ForEach(filteredCommands) { cmd in
-                        VStack(alignment: .leading, spacing: spacingSmall) {
-                            Text("➜ \(cmd.name)")
-                                .font(.system(.body, design: .monospaced))
-                                .fontWeight(.bold)
-                                .foregroundColor(.primary)
+        HStack(spacing: 7) {
+            Image(systemName: isSupported ? "checkmark.circle.fill" : "xmark.circle.fill")
+            Text(title)
+                .font(.caption.weight(.semibold))
 
-                            Text(cmd.description)
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-
-                            HStack(spacing: spacingLarge) {
-                                HStack(spacing: spacingSmall) {
-                                    Image(systemName: cmd.worksInBedrock
-                                          ? "checkmark.circle.fill"
-                                          : "xmark.circle.fill")
-                                    Text("Bedrock")
-                                        .font(.caption)
-                                    if let lvl = cmd.opLevelBedrock {
-                                        Text("OP \(lvl)")
-                                            .font(.caption2)
-                                            .foregroundColor(.secondary)
-                                            .padding(.vertical, 2)
-                                            .padding(.horizontal, 6)
-                                            .background(
-                                                Capsule()
-                                                    .fill(color(forOP: lvl).opacity(0.2))
-                                            )
-                                            .overlay(
-                                                Capsule()
-                                                    .stroke(color(forOP: lvl), lineWidth: 1)
-                                            )
-                                            .onTapGesture {
-                                                withAnimation {
-                                                    proxy.scrollTo("opExplanation", anchor: .top)
-                                                }
-                                            }
-                                        }
-                                }
-                                .foregroundColor(
-                                    cmd.worksInBedrock
-                                        ? Color.userAccentColor
-                                        : .red
-                                )
-                                .accessibilityLabel("Bedrock Edition \(cmd.worksInBedrock ? "supported" : "not supported")\(cmd.worksInBedrock && cmd.opLevelBedrock != nil ? ", requires OP level \(cmd.opLevelBedrock!)" : "")")
-                                .accessibilityHint(cmd.worksInBedrock ? "Double tap OP level to see explanation" : "")
-
-                                HStack(spacing: spacingSmall) {
-                                    Image(systemName: cmd.worksInJava
-                                          ? "checkmark.circle.fill"
-                                          : "xmark.circle.fill")
-                                    Text("Java")
-                                        .font(.caption)
-                                    if let lvl = cmd.opLevelJava {
-                                        Text("OP \(lvl)")
-                                            .font(.caption2)
-                                            .foregroundColor(.secondary)
-                                            .padding(.vertical, 2)
-                                            .padding(.horizontal, 6)
-                                            .background(
-                                                Capsule()
-                                                    .fill(color(forOP: lvl).opacity(0.2))
-                                            )
-                                            .overlay(
-                                                Capsule()
-                                                    .stroke(color(forOP: lvl), lineWidth: 1)
-                                            )
-                                            .onTapGesture {
-                                                withAnimation {
-                                                    proxy.scrollTo("opExplanation", anchor: .top)
-                                                }
-                                            }
-                                        }
-                                }
-                                .foregroundColor(
-                                    cmd.worksInJava
-                                        ? Color.userAccentColor
-                                        : .red
-                                )
-                                .accessibilityLabel("Java Edition \(cmd.worksInJava ? "supported" : "not supported")\(cmd.worksInJava && cmd.opLevelJava != nil ? ", requires OP level \(cmd.opLevelJava!)" : "")")
-                                .accessibilityHint(cmd.worksInJava ? "Double tap OP level to see explanation" : "")
-                            }
-                        }
-                        .padding(.vertical, horizontalSizeClass == .regular ? paddingVertical * 1.5 : paddingVertical)
-                        .listRowInsets(EdgeInsets(
-                            top: horizontalSizeClass == .regular ? paddingVertical * 1.5 : paddingVertical,
-                            leading: horizontalSizeClass == .regular ? paddingHorizontal * 1.33 : paddingHorizontal,
-                            bottom: horizontalSizeClass == .regular ? paddingVertical * 1.5 : paddingVertical,
-                            trailing: horizontalSizeClass == .regular ? paddingHorizontal * 1.33 : paddingHorizontal
-                        ))
-                        .contextMenu {
-                            Button("Copy Command") {
-                                UIPasteboard.general.string = cmd.name
-                            }
-                        }
-                        .accessibilityElement(children: .combine)
-                        .accessibilityLabel("Command: \(cmd.name), \(cmd.description)")
-                        .accessibilityHint("Double tap to copy the command")
-                    }
-
-                    Section(header: Text("OP Levels").id("opExplanation")) {
-                        VStack(alignment: .leading, spacing: spacingSmall) {
-                            Text("Higher OP levels include all permissions of the lower ones.")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-
-                            Text("Bedrock Edition")
-                                .font(.headline)
-                            VStack(alignment: .leading, spacing: spacingSmall) {
-                                Text("• 1: Operator – Basic commands & command blocks")
-                                Text("• 2: Admin – Server commands")
-                                Text("• 3: Host – World & automation management")
-                                Text("• 4: Owner – Full server control")
-                            }
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-
-                            Text("Java Edition")
-                                .font(.headline)
-                                .padding(.top, spacingSmall)
-                            VStack(alignment: .leading, spacing: spacingSmall) {
-                                Text("• 0: All – Basic commands")
-                                Text("• 1: Moderator – Bypass spawn protection")
-                                Text("• 2: GameMaster – Command blocks & extra commands")
-                                Text("• 3: Admin – Multiplayer management")
-                                Text("• 4: Owner – Full server control")
-                            }
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        }
-                        .padding(.vertical, horizontalSizeClass == .regular ? paddingVertical * 1.5 : paddingVertical)
-                        .listRowInsets(EdgeInsets(
-                            top: horizontalSizeClass == .regular ? paddingVertical * 1.5 : paddingVertical,
-                            leading: horizontalSizeClass == .regular ? paddingHorizontal * 1.33 : paddingHorizontal,
-                            bottom: horizontalSizeClass == .regular ? paddingVertical * 1.5 : paddingVertical,
-                            trailing: horizontalSizeClass == .regular ? paddingHorizontal * 1.33 : paddingHorizontal
-                        ))
-                        .accessibilityElement(children: .combine)
-                        .accessibilityLabel("OP Levels explanation: Higher OP levels include all permissions of the lower ones. Bedrock Edition: 1 Operator, basic commands and command blocks; 2 Admin, server commands; 3 Host, world and automation management; 4 Owner, full server control. Java Edition: 0 All, basic commands; 1 Moderator, bypass spawn protection; 2 GameMaster, command blocks and extra commands; 3 Admin, multiplayer management; 4 Owner, full server control.")
-                    }
-                }
-                .listStyle(InsetGroupedListStyle())
-                .refreshable {
-                    dataManager.fetchConsoleCommands()
-                }
-                .scrollContentBackground(.hidden)
-                .background(Color(UIColor.systemGroupedBackground))
-                .searchable(
-                    text: $searchText,
-                    placement: .navigationBarDrawer(displayMode: .always),
-                    prompt: "Search commands…"
-                )
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        Menu {
-                            ForEach(EditionFilter.allCases) { filter in
-                                Button(action: {
-                                    editionFilter = filter
-                                    HapticFeedback.selection()
-                                }) {
-                                    HStack {
-                                        Text(filter.rawValue)
-                                        if filter == editionFilter {
-                                            Spacer()
-                                            Image(systemName: "checkmark")
-                                        }
-                                    }
-                                }
-                            }
-                        } label: {
-                            Image(systemName: "line.3.horizontal.decrease.circle")
-                                .imageScale(.large)
-                        }
-                        .simultaneousGesture(TapGesture().onEnded { HapticFeedback.impact() })
-                        .accessibilityLabel("Filter commands by edition")
-                        .accessibilityHint("Choose All Editions, Bedrock Edition, or Java Edition")
-                    }
-                }
-                .navigationTitle("Console Commands")
-                .navigationBarTitleDisplayMode(.large)
-                .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-                .safeAreaInset(edge: .top) { Color.clear.frame(height: 0) }
-                .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 0) }
-                .preferredColorScheme(
-                    colorSchemePreference == "system"
-                        ? nil
-                        : (colorSchemePreference == "light" ? .light : .dark)
-                )
-                .accentColor(Color.userAccentColor)
-                .onAppear {
-                    dataManager.fetchConsoleCommands()
-                }
-                .dynamicTypeSize(.xSmall ... .accessibility5)
+            if isSupported, let opLevel {
+                Button("OP \(opLevel)", action: onShowOPLevels)
+                    .font(.caption2.bold())
+                    .foregroundStyle(opColor)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 4)
+                    .background(opColor.opacity(0.12), in: Capsule())
+                    .buttonStyle(.plain)
+                    .accessibilityHint("Jumps to the operator level explanation")
             }
         }
+        .foregroundStyle(isSupported ? Color.userAccentColor : Color.red)
+        .padding(.horizontal, 9)
+        .padding(.vertical, 7)
+        .background(
+            (isSupported ? Color.userAccentColor : Color.red).opacity(0.08),
+            in: Capsule()
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(title) Edition \(isSupported ? "supported" : "not supported")")
+    }
+}
+
+private struct OPLevelsCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            CraftifySectionHeader(
+                title: "Operator Levels",
+                detail: "Higher levels include every permission from the lower levels.",
+                symbol: "person.badge.key.fill"
+            )
+
+            ViewThatFits(in: .horizontal) {
+                HStack(alignment: .top, spacing: 18) {
+                    edition(title: "Bedrock Edition", symbol: "cube.fill", levels: bedrockLevels)
+                    edition(title: "Java Edition", symbol: "cup.and.heat.waves.fill", levels: javaLevels)
+                }
+                VStack(alignment: .leading, spacing: 18) {
+                    edition(title: "Bedrock Edition", symbol: "cube.fill", levels: bedrockLevels)
+                    edition(title: "Java Edition", symbol: "cup.and.heat.waves.fill", levels: javaLevels)
+                }
+            }
+        }
+        .padding(20)
+        .craftifyCard(cornerRadius: 24)
+    }
+
+    private var bedrockLevels: [(String, String)] {
+        [
+            ("1 · Operator", "Basic commands and command blocks"),
+            ("2 · Admin", "Server commands"),
+            ("3 · Host", "World and automation management"),
+            ("4 · Owner", "Full server control")
+        ]
+    }
+
+    private var javaLevels: [(String, String)] {
+        [
+            ("0 · All", "Basic commands"),
+            ("1 · Moderator", "Bypass spawn protection"),
+            ("2 · GameMaster", "Command blocks and extra commands"),
+            ("3 · Admin", "Multiplayer management"),
+            ("4 · Owner", "Full server control")
+        ]
+    }
+
+    private func edition(title: String, symbol: String, levels: [(String, String)]) -> some View {
+        VStack(alignment: .leading, spacing: 11) {
+            Label(title, systemImage: symbol)
+                .font(.headline)
+                .foregroundStyle(Color.userAccentColor)
+            ForEach(levels, id: \.0) { level in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(level.0).font(.subheadline.bold())
+                    Text(level.1).font(.caption).foregroundStyle(.secondary)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(15)
+        .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .accessibilityElement(children: .combine)
     }
 }

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -6,93 +6,55 @@
 //
 
 import SwiftUI
-import Combine
-import CloudKit
 import UIKit
 
 struct ContentView: View {
     @EnvironmentObject private var dataManager: DataManager
-    @AppStorage("colorSchemePreference") private var colorSchemePreference: String = "system"
-    @AppStorage("accentColorPreference") private var accentColorPreference: String = "default"
+    @AppStorage("colorSchemePreference") private var colorSchemePreference = "system"
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     @State private var selectedTab = 0
     @State private var navigationPath = NavigationPath()
 
     var body: some View {
         ZStack {
-            // 1) solid base so the TabView never floats transparent
-            Color(.systemGroupedBackground)
-                .ignoresSafeArea()
+            AppBackground().ignoresSafeArea()
 
-            // 2) your TabView
             TabView(selection: $selectedTab) {
-                RecipesTabView(
-                    navigationPath: $navigationPath,
-                    accentColorPreference: accentColorPreference
-                )
-                .tabItem {
-                    Label("Recipes", systemImage: "square.grid.2x2")
-                }
-                .tag(0)
-                .accessibilityLabel("Recipes tab")
-                .accessibilityHint("View all recipes")
+                RecipesTabView(navigationPath: $navigationPath)
+                    .tabItem { Label("Recipes", systemImage: "square.grid.2x2") }
+                    .tag(0)
+                    .accessibilityLabel("Recipes tab")
+                    .accessibilityHint("Browse the Craftify recipe library")
 
                 ChestsView()
-                    .tabItem {
-                        Label("Chests", systemImage: "shippingbox.fill")
-                    }
+                    .tabItem { Label("Chests", systemImage: "shippingbox.fill") }
                     .tag(1)
                     .accessibilityLabel("Chests tab")
-                    .accessibilityHint("Organize recipes in chests")
+                    .accessibilityHint("Organize recipes in synced chests")
 
                 MoreView()
-                    .tabItem {
-                        Label("More", systemImage: "ellipsis.circle")
-                    }
+                    .tabItem { Label("More", systemImage: "ellipsis.circle") }
                     .tag(2)
                     .accessibilityLabel("More tab")
-                    .accessibilityHint("Access additional settings and features")
+                    .accessibilityHint("Open Craftify tools, settings, and information")
 
                 RecipeSearchView()
-                    .tabItem {
-                        // on iPadOS 18+, show icon-only
-                        if UIDevice.current.userInterfaceIdiom == .pad {
-                            Image(systemName: "magnifyingglass")
-                        } else {
-                            Label("Search", systemImage: "magnifyingglass")
-                        }
-                    }
+                    .tabItem { Label("Search", systemImage: "magnifyingglass") }
                     .tag(3)
                     .accessibilityLabel("Search tab")
-                    .accessibilityHint("Search for recipes")
+                    .accessibilityHint("Search recipes by name or ingredient")
             }
-            .accentColor(Color.userAccentColor)
-            .preferredColorScheme(
-                colorSchemePreference == "system" ? nil :
-                    (colorSchemePreference == "light" ? .light : .dark)
-            )
-            .ignoresSafeArea(edges: .bottom)
+            .tint(Color.userAccentColor(for: accentColorPreference))
+            .preferredColorScheme(preferredColorScheme)
 
-            // 3) manual-sync overlay
             if dataManager.isManualSyncing {
                 SyncOverlayView(
                     horizontalSizeClass: horizontalSizeClass,
                     message: "Syncing Recipes…"
                 )
-                .background(
-                    Group {
-                        if #available(iOS 26.0, *) {
-                            VisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
-                                .ignoresSafeArea()
-                        } else {
-                            Color.clear
-                        }
-                    }
-                )
-                .opacity(1)
-                .animation(.easeInOut(duration: 0.3), value: dataManager.isManualSyncing)
+                .transition(.opacity)
                 .zIndex(2)
             }
 
@@ -110,14 +72,7 @@ struct ContentView: View {
                 .zIndex(3)
             }
         }
-        // 4) nav-bar material
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-        .background {
-            if #available(iOS 26.0, *) {
-                VisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
-                    .ignoresSafeArea()
-            }
-        }
+        .animation(.easeInOut(duration: 0.25), value: dataManager.isManualSyncing)
         .sensoryFeedback(.success, trigger: dataManager.newRecipeAnnouncement?.id)
         .onChange(of: selectedTab) { _, newValue in
             HapticFeedback.selection()
@@ -129,203 +84,168 @@ struct ContentView: View {
         .dynamicTypeSize(.xSmall ... .accessibility5)
     }
 
+    private var preferredColorScheme: ColorScheme? {
+        switch colorSchemePreference {
+        case "light": .light
+        case "dark": .dark
+        default: nil
+        }
+    }
+
     private func tabName(for tag: Int) -> String {
         switch tag {
-        case 0: return "Recipes"
-        case 1: return "Chests"
-        case 2: return "More"
-        case 3: return "Search"
-        default: return "Unknown"
+        case 0: "Recipes"
+        case 1: "Chests"
+        case 2: "More"
+        case 3: "Search"
+        default: "Unknown"
         }
     }
 }
 
-// MARK: ––––––––––––––––––––––––––––––––––––––––––––––––––
-
 struct RecipesTabView: View {
     @EnvironmentObject private var dataManager: DataManager
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Binding var navigationPath: NavigationPath
-    let accentColorPreference: String
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            CategoryView(
-                navigationPath: $navigationPath,
-                accentColorPreference: accentColorPreference
-            )
-            .navigationTitle("Craftify")
-            .navigationBarTitleDisplayMode(.large)
-            .toolbar(.visible, for: .navigationBar)
-            // Let the home hero continue behind the system title and controls.
-            // The title remains system-managed (and therefore accessible), while
-            // hiding only the bar's background prevents a stacked-header look.
-            .toolbarBackground(.hidden, for: .navigationBar)
-            .overlay {
-                if dataManager.isLoading && dataManager.recipes.isEmpty {
-                    VStack(spacing: 12) {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                            .tint(Color.userAccentColor)
-                            .accessibilityValue("Loading")
-                        Text("Loading Recipes…")
-                            .font(.headline)
-                            .foregroundColor(.secondary)
+            CategoryView()
+                .navigationTitle("Craftify")
+                .navigationBarTitleDisplayMode(.large)
+                .toolbarBackground(.hidden, for: .navigationBar)
+                .overlay {
+                    if dataManager.isLoading && dataManager.recipes.isEmpty {
+                        loadingState
                     }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color(.systemGroupedBackground))
-                    .accessibilityElement(children: .combine)
-                    .accessibilityLabel("Loading Recipes")
-                    .accessibilityHint("Please wait while the recipes are being loaded")
                 }
-            }
-            .navigationDestination(for: Recipe.self) { recipe in
-                RecipeDetailView(
-                    recipe: recipe,
-                    navigationPath: $navigationPath
-                )
-            }
+                .navigationDestination(for: Recipe.self) { recipe in
+                    RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
+                }
         }
         .dynamicTypeSize(.xSmall ... .accessibility5)
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: 14) {
+            CraftifyAppMark(size: 72)
+            ProgressView()
+                .controlSize(.large)
+                .tint(Color.userAccentColor)
+                .accessibilityHidden(true)
+            Text("Preparing Your Recipe Book")
+                .font(.headline)
+            Text("Loading recipes and crafting images…")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background { AppBackground().ignoresSafeArea() }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Preparing your recipe book. Loading recipes and crafting images.")
     }
 }
 
 struct CategoryView: View {
-    @EnvironmentObject var dataManager: DataManager
-    @Binding var navigationPath: NavigationPath
+    @EnvironmentObject private var dataManager: DataManager
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    let accentColorPreference: String
-    @State private var selectedCategory: String? = nil
+    @AppStorage("isCraftifyPicksExpanded") private var isCraftifyPicksExpanded = true
+    @State private var selectedCategory: String?
     @State private var recommendedRecipes: [Recipe] = []
-    @AppStorage("isCraftifyPicksExpanded") private var isCraftifyPicksExpanded: Bool = true
     @State private var filteredRecipes: [String: [Recipe]] = [:]
-
-    private func updateFilteredRecipes() {
-        let source = selectedCategory == nil
-            ? dataManager.recipes
-            : dataManager.recipes.filter { $0.category == selectedCategory }
-
-        var groups = [String: [Recipe]]()
-        for recipe in source {
-            let key = String(recipe.name.prefix(1)).uppercased()
-            groups[key, default: []].append(recipe)
-        }
-        for key in groups.keys {
-            groups[key]?.sort { $0.name < $1.name }
-        }
-        filteredRecipes = groups
-    }
 
     var body: some View {
         VStack(spacing: 0) {
             CategoryFilterBar(
                 selectedCategory: $selectedCategory,
-                categories: dataManager.categories,
-                horizontalSizeClass: horizontalSizeClass
+                categories: dataManager.categories
             )
 
             RecipeListView(
                 recommendedRecipes: $recommendedRecipes,
                 isCraftifyPicksExpanded: $isCraftifyPicksExpanded,
-                filteredRecipes: filteredRecipes,
-                navigationPath: $navigationPath,
-                horizontalSizeClass: horizontalSizeClass,
-                accentColorPreference: accentColorPreference
+                filteredRecipes: filteredRecipes
             )
         }
-        .background(alignment: .top) {
-            // Keep the category controls visually connected to the navigation
-            // hero. Other screens use the navigation-only default height.
-            AppHeroBackground(additionalHeight: 64)
-        }
+        .background(alignment: .top) { AppHeroBackground(additionalHeight: 92) }
         .navigationTitle("Craftify")
         .navigationBarTitleDisplayMode(.large)
         .onAppear {
-            recommendedRecipes = Array(dataManager.recipes.shuffled().prefix(7))
+            refreshRecommendations()
             updateFilteredRecipes()
         }
         .onChange(of: dataManager.recipes) { _, _ in
-            recommendedRecipes = Array(dataManager.recipes.shuffled().prefix(7))
+            refreshRecommendations()
             updateFilteredRecipes()
         }
-        .onChange(of: selectedCategory) { _, _ in
-            updateFilteredRecipes()
-        }
+        .onChange(of: selectedCategory) { _, _ in updateFilteredRecipes() }
         .dynamicTypeSize(.xSmall ... .accessibility5)
+    }
+
+    private func refreshRecommendations() {
+        recommendedRecipes = Array(dataManager.recipes.shuffled().prefix(horizontalSizeClass == .regular ? 9 : 7))
+    }
+
+    private func updateFilteredRecipes() {
+        let source = selectedCategory.map { category in
+            dataManager.recipes.filter { $0.category == category }
+        } ?? dataManager.recipes
+
+        filteredRecipes = Dictionary(grouping: source) {
+            String($0.name.prefix(1)).uppercased()
+        }
+        .mapValues { $0.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending } }
     }
 }
 
 struct CategoryFilterBar: View {
     @Binding var selectedCategory: String?
     let categories: [String]
-    let horizontalSizeClass: UserInterfaceSizeClass?
-    @AppStorage("accentColorPreference") private var accentColorPreference: String = "default"
-    @ScaledMetric(relativeTo: .body) private var buttonPaddingHorizontal: CGFloat = 16
-    @ScaledMetric(relativeTo: .body) private var buttonPaddingVertical: CGFloat = 8
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
+
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                Button {
-                    selectedCategory = nil
-                    HapticFeedback.selection()
-                } label: {
-                    Text("All")
-                        .font(.body)
-                        .fontWeight(.bold)
-                        .padding(.horizontal, horizontalSizeClass == .regular ? buttonPaddingHorizontal * 1.5 : buttonPaddingHorizontal)
-                        .padding(.vertical, buttonPaddingVertical)
-                        .background(selectedCategory == nil ? Color.userAccentColor : Color(.secondarySystemBackground).opacity(0.88))
-                        .foregroundStyle(selectedCategory == nil ? Color.white : Color.primary)
-                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                        .overlay {
-                            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                .stroke(Color.primary.opacity(selectedCategory == nil ? 0 : 0.12), lineWidth: 1)
-                        }
-                }
-                .accessibilityLabel("Show all recipes")
-                .accessibilityHint("Displays recipes from all categories")
-
+                filterButton(title: "All", symbol: "square.grid.2x2", category: nil)
                 ForEach(categories, id: \.self) { category in
-                    Button {
-                        selectedCategory = category
-                        HapticFeedback.selection()
-                    } label: {
-                        Text(category)
-                            .font(.body)
-                            .fontWeight(.bold)
-                            .padding(.horizontal, horizontalSizeClass == .regular ? buttonPaddingHorizontal * 1.5 : buttonPaddingHorizontal)
-                            .padding(.vertical, buttonPaddingVertical)
-                            .background(selectedCategory == category ? Color.userAccentColor : Color(.secondarySystemBackground).opacity(0.88))
-                            .foregroundStyle(selectedCategory == category ? Color.white : Color.primary)
-                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-                            .overlay {
-                                RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                    .stroke(Color.primary.opacity(selectedCategory == category ? 0 : 0.12), lineWidth: 1)
-                            }
-                    }
-                    .accessibilityLabel("Show \(category) recipes")
-                    .accessibilityHint("Filters recipes to show only \(category) category")
+                    filterButton(title: category, symbol: "cube.fill", category: category)
                 }
             }
-            .id(accentColorPreference)
-            .padding(.horizontal, horizontalSizeClass == .regular ? buttonPaddingHorizontal * 1.5 : buttonPaddingHorizontal)
-            .padding(.vertical, buttonPaddingVertical)
+            .padding(7)
         }
-        .safeAreaInset(edge: .top) { Color.clear.frame(height: 0) }
-        .background(.ultraThinMaterial)
-        .overlay(alignment: .bottom) {
-            Divider().opacity(0.35)
+        .craftifyFloatingSurface(cornerRadius: 18)
+        .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+        .padding(.bottom, 8)
+        .id(accentColorPreference)
+        .accessibilityLabel("Recipe categories")
+    }
+
+    private func filterButton(title: String, symbol: String, category: String?) -> some View {
+        let isSelected = selectedCategory == category
+
+        return Button {
+            selectedCategory = category
+            HapticFeedback.selection()
+        } label: {
+            Label(title, systemImage: symbol)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(isSelected ? Color.white : Color.primary)
+                .padding(.horizontal, horizontalSizeClass == .regular ? 15 : 12)
+                .padding(.vertical, 9)
+                .background(
+                    isSelected ? Color.userAccentColor : Color.primary.opacity(0.055),
+                    in: Capsule()
+                )
         }
-        .dynamicTypeSize(.xSmall ... .accessibility5)
+        .buttonStyle(.plain)
+        .accessibilityLabel(isSelected ? "\(title), selected" : title)
+        .accessibilityHint("Filters the recipe library")
     }
 }
 
 struct AppHeroBackground: View {
-    /// The portion below the actual top safe area/navigation region that the
-    /// hero should cover. Passing `nil` fills the receiving view, which is
-    /// useful when a custom header is part of the hero.
     let additionalHeight: CGFloat?
-
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
 
     init(additionalHeight: CGFloat? = 0) {
@@ -334,35 +254,25 @@ struct AppHeroBackground: View {
 
     var body: some View {
         GeometryReader { geometry in
-            // Depending on its container, SwiftUI either reports the whole
-            // navigation region as a safe-area inset or positions the content
-            // below it. Taking the larger measurement handles both layouts,
-            // including taller Dynamic Island safe areas and large titles.
-            let navigationRegionHeight = max(
+            let navigationHeight = max(
                 geometry.safeAreaInsets.top,
                 max(geometry.frame(in: .global).minY, 0)
             )
-            let heroHeight = additionalHeight.map { navigationRegionHeight + $0 }
-                ?? (geometry.size.height + navigationRegionHeight)
+            let height = additionalHeight.map { navigationHeight + $0 }
+                ?? geometry.size.height + navigationHeight
 
             ZStack(alignment: .top) {
-                // Lists and scroll views deliberately hide their native
-                // grouped background. Keep everything below the hero on the
-                // shared accent-tinted app surface rather than leaving it
-                // transparent.
                 AppBackground()
-
                 LinearGradient(
                     colors: [
-                        Color.userAccentColor(for: accentColorPreference).opacity(0.42),
-                        Color.userAccentColor(for: accentColorPreference).opacity(0.18),
-                        Color.clear
+                        Color.userAccentColor(for: accentColorPreference).opacity(0.32),
+                        Color.userAccentColor(for: accentColorPreference).opacity(0.10),
+                        .clear
                     ],
                     startPoint: .topLeading,
                     endPoint: .bottomTrailing
                 )
-                .frame(maxWidth: .infinity)
-                .frame(height: heroHeight)
+                .frame(height: height)
             }
         }
         .ignoresSafeArea(edges: .top)
@@ -372,16 +282,23 @@ struct AppHeroBackground: View {
 
 struct RecipeListView: View {
     @EnvironmentObject private var dataManager: DataManager
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Binding var recommendedRecipes: [Recipe]
     @Binding var isCraftifyPicksExpanded: Bool
     let filteredRecipes: [String: [Recipe]]
-    @Binding var navigationPath: NavigationPath
-    let horizontalSizeClass: UserInterfaceSizeClass?
-    let accentColorPreference: String
-    @ScaledMetric(relativeTo: .body) private var gridSpacing: CGFloat = 16
-    @ScaledMetric(relativeTo: .body) private var picksSpacing: CGFloat = 8
-    @ScaledMetric(relativeTo: .body) private var paddingHorizontal: CGFloat = 16
-    @ScaledMetric(relativeTo: .body) private var paddingVertical: CGFloat = 8
+
+    private var recipeColumns: [GridItem] {
+        if horizontalSizeClass == .compact || dynamicTypeSize.isAccessibilitySize {
+            return [GridItem(.flexible())]
+        }
+        return CraftifyLayout.adaptiveColumns(
+            minimum: 320,
+            maximum: 520,
+            spacing: 16,
+            dynamicTypeSize: dynamicTypeSize
+        )
+    }
 
     var body: some View {
         Group {
@@ -389,218 +306,182 @@ struct RecipeListView: View {
                 EmptyRecipeView()
             } else {
                 ScrollView {
-                    LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                if !recommendedRecipes.isEmpty {
-                    Section {
-                        if isCraftifyPicksExpanded {
-                            ScrollView(.horizontal, showsIndicators: false) {
-                                LazyHStack(spacing: picksSpacing) {
-                                    ForEach(recommendedRecipes, id: \.name) { recipe in
-                                        NavigationLink {
-                                            RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
-                                        } label: {
-                                            RecipeCell(recipe: recipe, isCraftifyPick: true)
-                                        }
-                                        .buttonStyle(.plain)
-                                        .contentShape(Rectangle())
-                                    }
-                                }
-                                .padding(.horizontal, horizontalSizeClass == .regular ? paddingHorizontal * 1.5 : paddingHorizontal)
-                                .padding(.vertical, paddingVertical)
-                            }
+                    LazyVStack(alignment: .leading, spacing: 24) {
+                        if !recommendedRecipes.isEmpty {
+                            picksSection
                         }
-                    } header: {
-                        CraftifyPicksHeader(isExpanded: isCraftifyPicksExpanded, accentColorPreference: accentColorPreference) {
-                            withAnimation { isCraftifyPicksExpanded.toggle() }
-                        }
-                        .background(Color(.systemGroupedBackground))
-                    }
-                }
 
-                ForEach(filteredRecipes.keys.sorted(), id: \.self) { letter in
-                    Section {
-                        if horizontalSizeClass == .regular {
-                            // iPad: Two-column grid
-                            LazyVGrid(
-                                columns: [
-                                    GridItem(.flexible(), spacing: gridSpacing),
-                                    GridItem(.flexible(), spacing: gridSpacing)
-                                ],
-                                alignment: .leading,
-                                spacing: gridSpacing
-                            ) {
-                                ForEach(filteredRecipes[letter] ?? [], id: \.name) { recipe in
-                                    NavigationLink {
-                                        RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
-                                    } label: {
-                                        RecipeCell(recipe: recipe, isCraftifyPick: false)
-                                    }
-                                    .buttonStyle(.plain)
-                                    .contentShape(Rectangle())
-                                }
-                            }
-                            .padding(.horizontal, horizontalSizeClass == .regular ? paddingHorizontal * 1.5 : paddingHorizontal)
-                        } else {
-                            // iPhone: Single-column stack
-                            ForEach(filteredRecipes[letter] ?? [], id: \.name) { recipe in
-                                NavigationLink {
-                                    RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
-                                } label: {
-                                    RecipeCell(recipe: recipe, isCraftifyPick: false)
-                                }
-                                .buttonStyle(.plain)
-                                .contentShape(Rectangle())
-                            }
+                        ForEach(filteredRecipes.keys.sorted(), id: \.self) { letter in
+                            recipeSection(letter)
                         }
-                    } header: {
-                        Text(letter)
-                            .font(.headline)
-                            .fontWeight(.bold)
-                            .padding(.horizontal, horizontalSizeClass == .regular ? paddingHorizontal * 1.5 : paddingHorizontal)
-                            .padding(.vertical, paddingVertical)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .background(Color(.systemGroupedBackground))
                     }
-                    }
+                    .craftifyContentWidth()
+                    .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+                    .padding(.top, 8)
+                    .padding(.bottom, 32)
                 }
-                .scrollContentBackground(.hidden)
+                .scrollIndicators(.hidden)
             }
         }
+        .background { AppBackground().ignoresSafeArea() }
+    }
+
+    private var picksSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            CraftifyPicksHeader(isExpanded: isCraftifyPicksExpanded) {
+                withAnimation(.snappy) { isCraftifyPicksExpanded.toggle() }
+            }
+
+            if isCraftifyPicksExpanded {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    LazyHStack(spacing: 12) {
+                        ForEach(recommendedRecipes) { recipe in
+                            NavigationLink(value: recipe) {
+                                RecipeCell(recipe: recipe, isCraftifyPick: true)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                    .padding(.vertical, 5)
+                    .padding(.horizontal, 2)
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
         }
-        .id(accentColorPreference)
-        .background(Color(.systemGroupedBackground))
-        .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 0) }
-        .dynamicTypeSize(.xSmall ... .accessibility5)
+    }
+
+    private func recipeSection(_ letter: String) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(letter)
+                .font(.title2.bold())
+                .foregroundStyle(Color.userAccentColor)
+                .accessibilityAddTraits(.isHeader)
+
+            LazyVGrid(columns: recipeColumns, alignment: .leading, spacing: 12) {
+                ForEach(filteredRecipes[letter] ?? []) { recipe in
+                    NavigationLink(value: recipe) {
+                        RecipeCell(recipe: recipe, isCraftifyPick: false)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
     }
 }
 
 struct RecipeCell: View {
     let recipe: Recipe
     let isCraftifyPick: Bool
+
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.colorScheme) private var colorScheme
-    @ScaledMetric(relativeTo: .body) private var imageSizeRegular: CGFloat = 80
-    @ScaledMetric(relativeTo: .body) private var imageSizeCompact: CGFloat = 64
-    @ScaledMetric(relativeTo: .body) private var imageSizePickRegular: CGFloat = 96
-    @ScaledMetric(relativeTo: .body) private var imageSizePickCompact: CGFloat = 72
-    @ScaledMetric(relativeTo: .body) private var paddingHorizontal: CGFloat = 16
-    @ScaledMetric(relativeTo: .body) private var paddingVertical: CGFloat = 10
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
-        HStack(spacing: 12) {
-            CraftImage(key: recipe.image)
-                .scaledToFit()
-                .frame(
-                    width: isCraftifyPick
-                        ? (horizontalSizeClass == .regular ? imageSizePickRegular : imageSizePickCompact)
-                        : (horizontalSizeClass == .regular ? imageSizeRegular : imageSizeCompact),
-                    height: isCraftifyPick
-                        ? (horizontalSizeClass == .regular ? imageSizePickRegular : imageSizePickCompact)
-                        : (horizontalSizeClass == .regular ? imageSizeRegular : imageSizeCompact)
-                )
-                .cornerRadius(8)
-                .padding(4)
-                .accessibilityLabel("Image of \(recipe.name)")
+        Group {
+            if isCraftifyPick {
+                pickContent
+            } else {
+                rowContent
+            }
+        }
+        .craftifyCard(cornerRadius: 18)
+        .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(recipe.name), \(recipe.category.isEmpty ? "recipe" : "\(recipe.category) recipe")")
+        .accessibilityHint("Opens the crafting recipe")
+    }
+
+    private var rowContent: some View {
+        HStack(spacing: 14) {
+            recipeImage(size: dynamicTypeSize.isAccessibilitySize ? 72 : 62)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(recipe.name)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+                if !recipe.category.isEmpty {
+                    Label(recipe.category, systemImage: "tag.fill")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Color.userAccentColor)
+                        .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
+                }
+            }
+            Spacer(minLength: 4)
+            Image(systemName: "chevron.right")
+                .font(.caption.bold())
+                .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, minHeight: 86, alignment: .leading)
+    }
+
+    private var pickContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ZStack(alignment: .topLeading) {
+                AppBackground()
+                recipeImage(size: horizontalSizeClass == .regular ? 96 : 82)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .padding(10)
+                CraftifyStatusPill(title: "Pick", symbol: "sparkles")
+                    .padding(9)
+            }
+            .frame(height: horizontalSizeClass == .regular ? 142 : 124)
+            .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(recipe.name)
                     .font(.headline)
-                    .fontWeight(.bold)
-                    .foregroundColor(.primary)
+                    .foregroundStyle(.primary)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+                Text(recipe.category)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
-
-                if !recipe.category.isEmpty {
-                    Text(recipe.category)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                }
             }
-
-            Spacer()
-
-            Image(systemName: "chevron.right")
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(.gray)
-                .padding(.trailing, horizontalSizeClass == .regular ? paddingHorizontal * 0.75 : paddingHorizontal * 0.5)
+            .padding(.horizontal, 12)
+            .padding(.bottom, 12)
         }
-        .padding(.horizontal, horizontalSizeClass == .regular ? paddingHorizontal : paddingHorizontal * 0.75)
-        .padding(.vertical, paddingVertical)
-        .background(
-            Group {
-                if #available(iOS 26.0, *), colorScheme == .dark {
-                    VisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
-                        .cornerRadius(10)
-                } else {
-                    Color(.secondarySystemGroupedBackground)
-                    .cornerRadius(10)
-                }
-            }
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(
-                    Color.userAccentColor.opacity(colorScheme == .dark ? 0.7 : 0.3),
-                    style: isCraftifyPick
-                        ? StrokeStyle(lineWidth: 1)
-                        : StrokeStyle(lineWidth: 1, dash: [4, 4])
-                )
-        )
-        .padding(.horizontal, horizontalSizeClass == .regular ? paddingHorizontal * 1.5 : paddingHorizontal)
-        .padding(.vertical, 2)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(recipe.name), \(recipe.category.isEmpty ? "recipe" : "\(recipe.category) recipe")")
-        .accessibilityHint("Navigates to the detailed view of \(recipe.name)")
-        .dynamicTypeSize(.xSmall ... .accessibility5)
+        .frame(width: dynamicTypeSize.isAccessibilitySize ? 280 : (horizontalSizeClass == .regular ? 220 : 188))
+    }
+
+    private func recipeImage(size: CGFloat) -> some View {
+        CraftImage(key: recipe.image)
+            .scaledToFit()
+            .frame(width: size, height: size)
+            .padding(5)
+            .background(Color.userAccentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+            .accessibilityHidden(true)
     }
 }
 
 struct CraftifyPicksHeader: View {
-    var isExpanded: Bool
-    var accentColorPreference: String
-    var toggle: () -> Void
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.colorScheme) private var colorScheme
-    @ScaledMetric(relativeTo: .body) private var paddingHorizontal: CGFloat = 16
-    @ScaledMetric(relativeTo: .body) private var paddingVertical: CGFloat = 8
-    @ScaledMetric(relativeTo: .body) private var headerHeightRegular: CGFloat = 44
-    @ScaledMetric(relativeTo: .body) private var headerHeightCompact: CGFloat = 36
+    let isExpanded: Bool
+    let toggle: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
-            Button {
-                toggle()
-            } label: {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                    .font(.title2)
-                    .foregroundColor(.gray)
-                    .padding(8)
-                    .background(
-                        Group {
-                            if #available(iOS 26.0, *) {
-                                VisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
-                            } else {
-                                Color.gray.opacity(0.1)
-                            }
-                        }
-                    )
-                    .clipShape(Circle())
+        Button(action: toggle) {
+            HStack(spacing: 10) {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(Color.userAccentColor)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Craftify Picks")
+                        .font(.title3.bold())
+                        .foregroundStyle(.primary)
+                    Text("A fresh handful from the recipe book")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Image(systemName: isExpanded ? "chevron.up.circle.fill" : "chevron.down.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(Color.userAccentColor)
             }
             .contentShape(Rectangle())
-            .accessibilityLabel(isExpanded ? "Collapse Craftify Picks" : "Expand Craftify Picks")
-            .accessibilityHint("Toggles the visibility of recommended recipes")
-
-            Text("Craftify Picks")
-                .font(.title3)
-                .fontWeight(.bold)
-                .foregroundColor(.primary)
-
-            Spacer()
         }
-        .padding(.horizontal, horizontalSizeClass == .regular ? paddingHorizontal * 1.5 : paddingHorizontal)
-        .padding(.vertical, paddingVertical)
-        .background(Color(.systemGroupedBackground))
-        .frame(height: horizontalSizeClass == .regular ? headerHeightRegular : headerHeightCompact)
-        .dynamicTypeSize(.xSmall ... .accessibility5)
+        .buttonStyle(.plain)
+        .accessibilityLabel(isExpanded ? "Collapse Craftify Picks" : "Expand Craftify Picks")
+        .accessibilityHint("Shows or hides recommended recipes")
     }
 }

--- a/Craftify/CraftifyApp.swift
+++ b/Craftify/CraftifyApp.swift
@@ -6,26 +6,10 @@
 //
 
 import SwiftUI
-import UIKit
 import Combine
 
 @main
 struct CraftifyApp: App {
-    init() {
-        let tabBarAppearance = UITabBarAppearance()
-        if #available(iOS 26.0, *) {
-                // Liquid Glass: Use transparent background with vibrancy
-                tabBarAppearance.configureWithTransparentBackground()
-                let blurEffect = UIBlurEffect(style: .systemUltraThinMaterial)
-                tabBarAppearance.backgroundEffect = blurEffect
-                tabBarAppearance.backgroundColor = .clear
-        } else {
-            tabBarAppearance.configureWithDefaultBackground()
-        }
-        UITabBar.appearance().standardAppearance = tabBarAppearance
-        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
-    }
-
     @StateObject private var dataManager = DataManager()
     @AppStorage("hasLaunchedBefore") private var hasLaunchedBefore: Bool = false
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
@@ -55,24 +39,14 @@ struct CraftifyApp: App {
                                 isManual: false,
                                 waitForImages: !hasLaunchedBefore
                             )
-                        },
-                        horizontalSizeClass: UIDevice.current.userInterfaceIdiom == .pad ? .regular : .compact
+                        }
                     )
                     .environmentObject(dataManager)
-                    .background {
-                        if #available(iOS 26.0, *) {
-                            // Liquid Glass: Vibrant, translucent background
-                            VisualEffectView(effect: UIBlurEffect(style: .systemUltraThinMaterial))
-                                .ignoresSafeArea()
-                        }
-                    }
                     .zIndex(1)
                 }
             }
             .tint(Color.userAccentColor)
             .dynamicTypeSize(.xSmall ... .accessibility5)
-            .accessibilityElement(children: .contain)
-            .accessibilityLabel("Craftify App")
             .onAppear {
                 dataManager.fetchRecipes(
                     isManual: false,
@@ -94,24 +68,4 @@ struct CraftifyApp: App {
 
 extension Notification.Name {
     static let showOnboarding = Notification.Name("showOnboarding")
-}
-
-// Helper view for iOS 26 vibrancy effect
-@available(iOS 26.0, *)
-struct VisualEffectView: UIViewRepresentable {
-    let effect: UIVisualEffect
-
-    func makeUIView(context: Context) -> UIVisualEffectView {
-        let view = UIVisualEffectView(effect: effect)
-        let vibrancyEffect = UIVibrancyEffect(blurEffect: effect as! UIBlurEffect)
-        let vibrancyView = UIVisualEffectView(effect: vibrancyEffect)
-        view.contentView.addSubview(vibrancyView)
-        vibrancyView.frame = view.bounds
-        vibrancyView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-        return view
-    }
-
-    func updateUIView(_ uiView: UIVisualEffectView, context: Context) {
-        uiView.effect = effect
-    }
 }

--- a/Craftify/CraftifyDesignSystem.swift
+++ b/Craftify/CraftifyDesignSystem.swift
@@ -1,0 +1,359 @@
+//
+//  CraftifyDesignSystem.swift
+//  Craftify
+//
+//  Shared visual language for the Craftify experience.
+//
+
+import SwiftUI
+
+enum CraftifyLayout {
+    static let contentMaxWidth: CGFloat = 1_180
+    static let readingMaxWidth: CGFloat = 760
+    static let formMaxWidth: CGFloat = 820
+
+    static func pagePadding(for sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+        sizeClass == .regular ? 28 : 16
+    }
+
+    static func adaptiveColumns(
+        minimum: CGFloat,
+        maximum: CGFloat = 440,
+        spacing: CGFloat = 16,
+        dynamicTypeSize: DynamicTypeSize
+    ) -> [GridItem] {
+        if dynamicTypeSize.isAccessibilitySize {
+            return [GridItem(.flexible())]
+        }
+        return [GridItem(.adaptive(minimum: minimum, maximum: maximum), spacing: spacing)]
+    }
+}
+
+/// The app-wide canvas. The restrained 3×3 block motifs reference the
+/// crafting grid without turning every screen into a Minecraft texture.
+struct AppBackground: View {
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var accent: Color {
+        Color.userAccentColor(for: accentColorPreference)
+    }
+
+    var body: some View {
+        ZStack {
+            Color(.systemGroupedBackground)
+
+            LinearGradient(
+                colors: [
+                    accent.opacity(reduceTransparency ? 0.12 : (colorScheme == .dark ? 0.20 : 0.16)),
+                    accent.opacity(reduceTransparency ? 0.035 : 0.07),
+                    Color.clear
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            GeometryReader { geometry in
+                CraftifyBlockMotif()
+                    .frame(width: min(geometry.size.width * 0.52, 340))
+                    .rotationEffect(.degrees(-8))
+                    .offset(x: geometry.size.width * 0.60, y: -38)
+
+                CraftifyBlockMotif()
+                    .frame(width: min(geometry.size.width * 0.34, 220))
+                    .rotationEffect(.degrees(10))
+                    .offset(x: -70, y: geometry.size.height * 0.72)
+            }
+            .opacity(reduceTransparency ? 0.24 : 0.48)
+        }
+        .accessibilityHidden(true)
+    }
+}
+
+private struct CraftifyBlockMotif: View {
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
+
+    var body: some View {
+        let accent = Color.userAccentColor(for: accentColorPreference)
+
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: 7), count: 3),
+            spacing: 7
+        ) {
+            ForEach(0..<9, id: \.self) { index in
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(accent.opacity(index.isMultiple(of: 2) ? 0.095 : 0.045))
+                    .aspectRatio(1, contentMode: .fit)
+            }
+        }
+    }
+}
+
+struct CraftifyIconTile: View {
+    let symbol: String
+    var size: CGFloat = 56
+    var destructive = false
+
+    var body: some View {
+        Image(systemName: symbol)
+            .font(.system(size: size * 0.40, weight: .semibold))
+            .foregroundStyle(.white)
+            .frame(width: size, height: size)
+            .background(
+                destructive ? Color.red.gradient : Color.userAccentColor.gradient,
+                in: RoundedRectangle(cornerRadius: size * 0.28, style: .continuous)
+            )
+            .shadow(
+                color: (destructive ? Color.red : Color.userAccentColor).opacity(0.20),
+                radius: 10,
+                y: 5
+            )
+            .accessibilityHidden(true)
+    }
+}
+
+struct CraftifyAppMark: View {
+    var size: CGFloat = 88
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: size * 0.25, style: .continuous)
+                .fill(Color.userAccentColor.gradient)
+            Image(systemName: "hammer.fill")
+                .font(.system(size: size * 0.43, weight: .bold))
+                .foregroundStyle(.white)
+        }
+        .frame(width: size, height: size)
+        .shadow(color: Color.userAccentColor.opacity(0.24), radius: 16, y: 8)
+        .accessibilityHidden(true)
+    }
+}
+
+struct CraftifyHero: View {
+    let eyebrow: String?
+    let title: String
+    let detail: String
+    let symbol: String
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    init(eyebrow: String? = nil, title: String, detail: String, symbol: String) {
+        self.eyebrow = eyebrow
+        self.title = title
+        self.detail = detail
+        self.symbol = symbol
+    }
+
+    var body: some View {
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                verticalContent
+            } else {
+                ViewThatFits(in: .horizontal) {
+                    horizontalContent
+                    verticalContent
+                }
+            }
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity)
+        .craftifyCard(cornerRadius: 24)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var horizontalContent: some View {
+        HStack(spacing: 18) {
+            CraftifyIconTile(symbol: symbol, size: 64)
+            copy(alignment: .leading)
+        }
+    }
+
+    private var verticalContent: some View {
+        VStack(spacing: 14) {
+            CraftifyIconTile(symbol: symbol, size: 64)
+            copy(alignment: .center)
+        }
+    }
+
+    private func copy(alignment: TextAlignment) -> some View {
+        VStack(alignment: alignment == .center ? .center : .leading, spacing: 5) {
+            if let eyebrow {
+                Text(eyebrow.uppercased())
+                    .font(.caption.weight(.bold))
+                    .tracking(1.1)
+                    .foregroundStyle(Color.userAccentColor)
+            }
+            Text(title)
+                .font(.title2.bold())
+                .foregroundStyle(.primary)
+            Text(detail)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .multilineTextAlignment(alignment)
+        .frame(maxWidth: .infinity, alignment: alignment == .center ? .center : .leading)
+    }
+}
+
+struct CraftifySectionHeader: View {
+    let title: String
+    var detail: String?
+    var symbol: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            if let symbol {
+                Label(title, systemImage: symbol)
+                    .font(.title3.bold())
+                    .foregroundStyle(.primary)
+            } else {
+                Text(title)
+                    .font(.title3.bold())
+            }
+
+            if let detail {
+                Text(detail)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
+    }
+}
+
+struct CraftifyEmptyState: View {
+    let symbol: String
+    let title: String
+    let detail: String
+
+    var body: some View {
+        VStack(spacing: 13) {
+            CraftifyIconTile(symbol: symbol, size: 68)
+            Text(title)
+                .font(.title2.bold())
+                .multilineTextAlignment(.center)
+            Text(detail)
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: 520)
+        .padding(.horizontal, 28)
+        .padding(.vertical, 34)
+        .craftifyCard(cornerRadius: 24)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+struct CraftifyStatusPill: View {
+    let title: String
+    let symbol: String
+    var tint: Color = Color.userAccentColor
+
+    var body: some View {
+        Label(title, systemImage: symbol)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(tint.opacity(0.12), in: Capsule())
+    }
+}
+
+private struct CraftifyCardModifier: ViewModifier {
+    let cornerRadius: CGFloat
+    @Environment(\.colorSchemeContrast) private var contrast
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                Color(.secondarySystemGroupedBackground),
+                in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(
+                        Color.userAccentColor.opacity(contrast == .increased ? 0.42 : 0.16),
+                        lineWidth: contrast == .increased ? 1.5 : 1
+                    )
+            }
+            .shadow(color: .black.opacity(0.055), radius: 12, y: 5)
+    }
+}
+
+private struct CraftifyFloatingSurfaceModifier: ViewModifier {
+    let cornerRadius: CGFloat
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(
+                    .regular.tint(Color.userAccentColor(for: accentColorPreference).opacity(0.08)),
+                    in: .rect(cornerRadius: cornerRadius)
+                )
+        } else {
+            content
+                .background(
+                    .regularMaterial,
+                    in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                        .stroke(Color.userAccentColor.opacity(0.18), lineWidth: 1)
+                }
+        }
+    }
+}
+
+private struct CraftifyNavigationBarModifier: ViewModifier {
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+        } else {
+            content.toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        }
+    }
+}
+
+private struct CraftifyPageModifier: ViewModifier {
+    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
+
+    func body(content: Content) -> some View {
+        content
+            .background { AppBackground().ignoresSafeArea() }
+            .tint(Color.userAccentColor(for: accentColorPreference))
+            .id(accentColorPreference)
+            .modifier(CraftifyNavigationBarModifier())
+            .dynamicTypeSize(.xSmall ... .accessibility5)
+    }
+}
+
+extension View {
+    func craftifyCard(cornerRadius: CGFloat = 20) -> some View {
+        modifier(CraftifyCardModifier(cornerRadius: cornerRadius))
+    }
+
+    func craftifyFloatingSurface(cornerRadius: CGFloat = 24) -> some View {
+        modifier(CraftifyFloatingSurfaceModifier(cornerRadius: cornerRadius))
+    }
+
+    func craftifyNavigationBar() -> some View {
+        modifier(CraftifyNavigationBarModifier())
+    }
+
+    func craftifyPage() -> some View {
+        modifier(CraftifyPageModifier())
+    }
+
+    func craftifyContentWidth(_ maximum: CGFloat = CraftifyLayout.contentMaxWidth) -> some View {
+        frame(maxWidth: maximum)
+            .frame(maxWidth: .infinity)
+    }
+}

--- a/Craftify/EmptyRecipeView.swift
+++ b/Craftify/EmptyRecipeView.swift
@@ -8,31 +8,16 @@
 import SwiftUI
 
 struct EmptyRecipeView: View {
-    @ScaledMetric(relativeTo: .body) private var iconSize: CGFloat = 36
-    @ScaledMetric(relativeTo: .body) private var spacing: CGFloat = 12
-    @ScaledMetric(relativeTo: .body) private var padding: CGFloat = 16
-
     var body: some View {
-        VStack(spacing: spacing) {
-            Image(systemName: "arrow.triangle.2.circlepath.icloud")
-                .font(.system(size: iconSize))
-                .foregroundStyle(Color.userAccentColor)
-
-            Text("No recipes on this device")
-                .font(.title)
-                .bold()
-                .multilineTextAlignment(.center)
-
-            Text("Head to More and choose Sync Recipes to fetch the recipe library again.")
-                .font(.headline)
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-                .padding(.horizontal, padding)
-        }
+        CraftifyEmptyState(
+            symbol: "arrow.triangle.2.circlepath.icloud",
+            title: "No Recipes on This Device",
+            detail: "Open More and choose Sync Recipes & Images to rebuild your offline recipe book."
+        )
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(padding)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("No recipes on this device. Head to More and choose Sync Recipes to fetch the recipe library again.")
+        .padding(24)
+        .background { AppBackground().ignoresSafeArea() }
+        .accessibilityLabel("No recipes on this device. Open More and choose Sync Recipes and Images to rebuild your offline recipe book.")
         .dynamicTypeSize(.xSmall ... .accessibility5)
     }
 }

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -9,10 +9,19 @@ import SwiftUI
 
 struct MoreView: View {
     @EnvironmentObject private var dataManager: DataManager
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
     @State private var cooldownTask: Task<Void, Never>?
     @State private var remainingCooldownTime = 0
+
+    private var dashboardColumns: [GridItem] {
+        CraftifyLayout.adaptiveColumns(
+            minimum: dynamicTypeSize.isAccessibilitySize ? 280 : 260,
+            maximum: 420,
+            spacing: 14,
+            dynamicTypeSize: dynamicTypeSize
+        )
+    }
 
     private var syncDetail: String {
         guard let date = dataManager.lastUpdated else { return dataManager.syncStatus }
@@ -21,127 +30,155 @@ struct MoreView: View {
 
     var body: some View {
         NavigationStack {
-            List {
-                Section("Help & Reference") {
-                    destination("Report an Issue", systemImage: "exclamationmark.bubble.fill", hint: "Report a missing recipe or an error") {
-                        ReportRecipeView()
-                    }
-                    destination("Console Commands", systemImage: "terminal.fill", hint: "Browse Minecraft console commands") {
-                        CommandsView()
-                    }
-                }
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 24) {
+                    CraftifyHero(
+                        eyebrow: "Craftify Toolkit",
+                        title: "More Ways to Craft",
+                        detail: "Keep your recipe book current, find useful commands, personalize the app, and get help when you need it.",
+                        symbol: "hammer.circle.fill"
+                    )
 
-                Section {
-                    destination("About Craftify", systemImage: "info.circle.fill", hint: "View app information, appearance, release notes, support, and privacy") {
-                        AboutView()
-                    }
-                    destination("App Appearance", systemImage: "paintpalette.fill", hint: "Choose the app icon, color, and appearance") {
-                        AppAppearanceView()
-                    }
-                    Button {
-                        NotificationCenter.default.post(name: .showOnboarding, object: nil)
-                    } label: {
-                        accentLabel("Getting Started", systemImage: "lightbulb.fill")
-                    }
-                    .accessibilityHint("Revisit Craftify's introductory tips")
-                } header: {
-                    Text("Craftify")
-                }
+                    syncCard
 
-                Section {
-                    Button(action: syncRecipes) {
-                        Label {
-                            Text(dataManager.isLoading ? "Syncing Recipes & Images…" : "Sync Recipes & Images")
-                                .foregroundStyle(.primary)
-                        } icon: {
-                            if dataManager.isLoading {
-                                ProgressView()
-                                    .controlSize(.small)
-                            } else {
-                                Image(systemName: "arrow.clockwise")
-                                    .foregroundStyle(Color.userAccentColor)
-                            }
+                    CraftifySectionHeader(
+                        title: "Tools & Help",
+                        detail: "Useful extras for Craftify and your Minecraft world."
+                    )
+
+                    LazyVGrid(columns: dashboardColumns, spacing: 14) {
+                        destination(
+                            "Report an Issue",
+                            detail: "Request a missing recipe or flag an error.",
+                            systemImage: "exclamationmark.bubble.fill"
+                        ) { ReportRecipeView() }
+
+                        destination(
+                            "Console Commands",
+                            detail: "Browse commands for Bedrock and Java Edition.",
+                            systemImage: "terminal.fill"
+                        ) { CommandsView() }
+
+                        destination(
+                            "App Appearance",
+                            detail: "Choose your color, appearance, and app icon.",
+                            systemImage: "paintpalette.fill"
+                        ) { AppAppearanceView() }
+
+                        destination(
+                            "About Craftify",
+                            detail: "Release notes, support, privacy, and credits.",
+                            systemImage: "info.circle.fill"
+                        ) { AboutView() }
+
+                        Button {
+                            HapticFeedback.impact(.light)
+                            NotificationCenter.default.post(name: .showOnboarding, object: nil)
+                        } label: {
+                            dashboardTile(
+                                title: "Getting Started",
+                                detail: "Revisit the guided tour of Craftify.",
+                                systemImage: "lightbulb.fill"
+                            )
                         }
-                    }
-                    .disabled(dataManager.isLoading || !dataManager.isConnected || remainingCooldownTime > 0)
-                    .accessibilityHint(syncHint)
-
-                    syncStatus
-                } header: {
-                    Text("Data Sync")
-                } footer: {
-                    if remainingCooldownTime > 0 {
-                        Text("Sync is available again in \(remainingCooldownTime) second\(remainingCooldownTime == 1 ? "" : "s").")
-                            .contentTransition(.numericText())
-                    } else if !dataManager.isConnected {
-                        Text("Connect to the internet to sync recipes and images. Craftify will keep your existing data available offline.")
+                        .buttonStyle(.plain)
+                        .accessibilityHint("Opens Craftify’s introductory guide")
                     }
                 }
+                .craftifyContentWidth()
+                .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+                .padding(.top, 12)
+                .padding(.bottom, 32)
             }
-            .listStyle(.insetGrouped)
-            .listSectionSpacing(24)
-            .scrollContentBackground(.hidden)
-            .background(Color(.systemGroupedBackground))
-            .tint(Color.userAccentColor)
             .navigationTitle("More")
             .navigationBarTitleDisplayMode(.large)
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .craftifyPage()
             .alert("Unable to Sync", isPresented: errorBinding) {
                 Button("OK", role: .cancel) { dataManager.errorMessage = nil }
             } message: {
                 Text(dataManager.errorMessage ?? "Please try again.")
             }
-            .onAppear {
-                dataManager.syncRecentSearches()
-            }
+            .onAppear { dataManager.syncRecentSearches() }
             .onDisappear { stopCooldown() }
         }
+    }
+
+    private var syncCard: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 14) {
+                CraftifyIconTile(
+                    symbol: dataManager.isConnected ? "icloud.and.arrow.down.fill" : "icloud.slash.fill",
+                    size: 58
+                )
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Recipe Book Sync")
+                        .font(.title3.bold())
+                    Text("Download new recipes and image updates for reliable offline access.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 9) { syncPills }
+                VStack(alignment: .leading, spacing: 9) { syncPills }
+            }
+
+            Text(syncDetail)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            Button(action: syncRecipes) {
+                Label(
+                    dataManager.isLoading ? "Syncing Recipes & Images…" : "Sync Recipes & Images",
+                    systemImage: dataManager.isLoading ? "hourglass" : "arrow.clockwise"
+                )
+                .font(.headline)
+                .frame(maxWidth: .infinity, minHeight: 48)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(dataManager.isLoading || !dataManager.isConnected || remainingCooldownTime > 0)
+            .accessibilityHint(syncHint)
+
+            if remainingCooldownTime > 0 {
+                Label(
+                    "Sync is available again in \(remainingCooldownTime) second\(remainingCooldownTime == 1 ? "" : "s").",
+                    systemImage: "timer"
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .contentTransition(.numericText())
+            } else if !dataManager.isConnected {
+                Label(
+                    "You’re offline. Your downloaded recipe book remains available.",
+                    systemImage: "wifi.slash"
+                )
+                .font(.footnote)
+                .foregroundStyle(.orange)
+            }
+        }
+        .padding(20)
+        .craftifyCard(cornerRadius: 24)
+    }
+
+    @ViewBuilder
+    private var syncPills: some View {
+        CraftifyStatusPill(
+            title: dataManager.isConnected ? "Online" : "Offline",
+            symbol: dataManager.isConnected ? "wifi" : "wifi.slash",
+            tint: dataManager.isConnected ? .green : .red
+        )
+        CraftifyStatusPill(
+            title: "\(dataManager.recipes.count.formatted()) recipes",
+            symbol: "book.closed.fill"
+        )
     }
 
     private var syncHint: String {
         if !dataManager.isConnected { return "Unavailable while offline" }
         if remainingCooldownTime > 0 { return "Available in \(remainingCooldownTime) seconds" }
-        return "Fetch the latest Minecraft recipes and images"
-    }
-
-    @ViewBuilder
-    private var syncStatus: some View {
-        if dynamicTypeSize.isAccessibilitySize {
-            VStack(alignment: .leading, spacing: 10) {
-                connectionStatus
-                recipeCountStatus
-                syncDetailText
-            }
-        } else {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 16) {
-                    connectionStatus
-                    recipeCountStatus
-                }
-                syncDetailText
-            }
-        }
-    }
-
-    private var connectionStatus: some View {
-        syncStatusItem(
-            dataManager.isConnected ? "Online" : "Offline",
-            systemImage: dataManager.isConnected ? "wifi" : "wifi.slash",
-            color: dataManager.isConnected ? .green : .red
-        )
-    }
-
-    private var recipeCountStatus: some View {
-        syncStatusItem(
-            "\(dataManager.recipes.count.formatted()) recipes",
-            systemImage: "book.closed.fill"
-        )
-    }
-
-    private var syncDetailText: some View {
-        Text(syncDetail)
-            .font(.footnote)
-            .foregroundStyle(.secondary)
+        return "Fetches the latest Minecraft recipes and images"
     }
 
     private var errorBinding: Binding<Bool> {
@@ -151,33 +188,41 @@ struct MoreView: View {
         )
     }
 
-    private func syncStatusItem(_ title: String, systemImage: String, color: Color = .secondary) -> some View {
-        Label(title, systemImage: systemImage)
-            .font(.caption2)
-            .foregroundStyle(color)
-            .lineLimit(1)
-    }
-
     private func destination<Destination: View>(
         _ title: String,
+        detail: String,
         systemImage: String,
-        hint: String,
         @ViewBuilder destination: () -> Destination
     ) -> some View {
         NavigationLink(destination: destination()) {
-            accentLabel(title, systemImage: systemImage)
+            dashboardTile(title: title, detail: detail, systemImage: systemImage)
         }
-        .accessibilityHint(hint)
+        .buttonStyle(.plain)
+        .accessibilityHint("Opens \(title)")
     }
 
-    private func accentLabel(_ title: String, systemImage: String) -> some View {
-        Label {
-            Text(title)
-                .foregroundStyle(.primary)
-        } icon: {
-            Image(systemName: systemImage)
-                .foregroundStyle(Color.userAccentColor)
+    private func dashboardTile(title: String, detail: String, systemImage: String) -> some View {
+        HStack(spacing: 14) {
+            CraftifyIconTile(symbol: systemImage, size: 50)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(detail)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 2)
+            Image(systemName: "chevron.right")
+                .font(.caption.bold())
+                .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
         }
+        .padding(14)
+        .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
+        .craftifyCard(cornerRadius: 18)
+        .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
     }
 
     private func syncRecipes() {
@@ -185,9 +230,7 @@ struct MoreView: View {
         HapticFeedback.impact(.light)
         dataManager.fetchRecipes(isManual: true) {
             Task { @MainActor in
-                if dataManager.isRecipeFetchOnCooldown() {
-                    beginCooldown()
-                }
+                if dataManager.isRecipeFetchOnCooldown() { beginCooldown() }
             }
         }
     }
@@ -215,7 +258,7 @@ struct MoreView: View {
 
 struct AboutView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     private var appVersion: String {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
@@ -223,72 +266,110 @@ struct AboutView: View {
         return "Version \(version) • Build \(build)"
     }
 
+    private var linkColumns: [GridItem] {
+        CraftifyLayout.adaptiveColumns(
+            minimum: dynamicTypeSize.isAccessibilitySize ? 280 : 240,
+            maximum: 360,
+            spacing: 14,
+            dynamicTypeSize: dynamicTypeSize
+        )
+    }
+
     var body: some View {
-        List {
-            Section {
-                VStack(spacing: 12) {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 24) {
+                VStack(spacing: 14) {
                     Image("AppIconPreview")
                         .resizable()
                         .scaledToFit()
-                        .frame(width: horizontalSizeClass == .regular ? 104 : 88, height: horizontalSizeClass == .regular ? 104 : 88)
-                        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                        .frame(width: horizontalSizeClass == .regular ? 112 : 94)
+                        .clipShape(RoundedRectangle(cornerRadius: 23, style: .continuous))
+                        .shadow(color: Color.userAccentColor.opacity(0.20), radius: 16, y: 8)
                         .accessibilityLabel("Craftify app icon")
 
                     Text("Craftify for Minecraft")
-                        .font(.title.bold())
+                        .font(.largeTitle.bold())
                         .multilineTextAlignment(.center)
                     Text(appVersion)
-                        .font(.subheadline)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Color.userAccentColor)
+                    Text("A focused crafting companion for discovering recipes and planning projects in synced chests.")
+                        .font(.body)
                         .foregroundStyle(.secondary)
-                    Text("A focused companion for finding Minecraft recipes and organizing recipes in synced chests.")
                         .multilineTextAlignment(.center)
-                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: 560)
                 }
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .accessibilityElement(children: .combine)
-            }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 28)
+                .craftifyCard(cornerRadius: 26)
 
-            Section("Information") {
-                NavigationLink(destination: ReleaseNotesView()) {
-                    accentLabel("Release Notes", systemImage: "sparkles")
+                CraftifySectionHeader(title: "Information")
+                LazyVGrid(columns: linkColumns, spacing: 14) {
+                    aboutDestination("Release Notes", detail: "See what changed in every Craftify build.", symbol: "sparkles") {
+                        ReleaseNotesView()
+                    }
+                    aboutDestination("Support & Privacy", detail: "Contact support or manage your data.", symbol: "hand.raised.fill") {
+                        SupportView()
+                    }
                 }
-                NavigationLink(destination: SupportView()) {
-                    accentLabel("Support & Privacy", systemImage: "hand.raised.fill")
-                }
-            }
 
-            Section("Acknowledgements") {
-                Link(destination: URL(string: "https://minecraft.wiki/")!) {
-                    accentLabel("Minecraft Wiki", systemImage: "arrow.up.right.square")
+                VStack(alignment: .leading, spacing: 14) {
+                    CraftifySectionHeader(title: "Acknowledgements", symbol: "heart.fill")
+                    Link(destination: URL(string: "https://minecraft.wiki/")!) {
+                        Label("Visit Minecraft Wiki", systemImage: "arrow.up.right.square")
+                            .font(.headline)
+                    }
+                    Text("Thank you to the Minecraft Wiki contributors for the recipe knowledge and thumbnails that help power Craftify.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
                 }
-                Text("Thank you to the Minecraft Wiki contributors for the recipe knowledge and thumbnails that help power Craftify.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
+                .padding(18)
+                .craftifyCard(cornerRadius: 22)
 
-            Section {
-                Text("Craftify for Minecraft is an independent app and is not approved by or associated with Mojang or Microsoft.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                Label(
+                    "Craftify for Minecraft is an independent app and is not approved by or associated with Mojang or Microsoft.",
+                    systemImage: "info.circle"
+                )
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .padding(16)
+                .craftifyCard(cornerRadius: 18)
             }
+            .craftifyContentWidth(CraftifyLayout.formMaxWidth)
+            .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+            .padding(.top, 12)
+            .padding(.bottom, 32)
         }
-        .listStyle(.insetGrouped)
-        .scrollContentBackground(.hidden)
-        .background(Color(.systemGroupedBackground))
-        .tint(Color.userAccentColor)
         .navigationTitle("About Craftify")
         .navigationBarTitleDisplayMode(.large)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .craftifyPage()
     }
 
-    private func accentLabel(_ title: String, systemImage: String) -> some View {
-        Label {
-            Text(title)
-                .foregroundStyle(.primary)
-        } icon: {
-            Image(systemName: systemImage)
-                .foregroundStyle(Color.userAccentColor)
+    private func aboutDestination<Destination: View>(
+        _ title: String,
+        detail: String,
+        symbol: String,
+        @ViewBuilder destination: () -> Destination
+    ) -> some View {
+        NavigationLink(destination: destination()) {
+            HStack(spacing: 14) {
+                CraftifyIconTile(symbol: symbol, size: 50)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title).font(.headline).foregroundStyle(.primary)
+                    Text(detail).font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 2)
+                Image(systemName: "chevron.right")
+                    .font(.caption.bold())
+                    .foregroundStyle(.tertiary)
+                    .accessibilityHidden(true)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, minHeight: 86, alignment: .leading)
+            .craftifyCard(cornerRadius: 18)
         }
+        .buttonStyle(.plain)
+        .accessibilityHint("Opens \(title)")
     }
 }

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -18,10 +18,10 @@ struct OnboardingView: View {
     let dismissAfterLoading: Bool
     let onDismiss: () -> Void
     let onRetry: () -> Void
-    let horizontalSizeClass: UserInterfaceSizeClass?
 
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @State private var step = 0
     @State private var isFinishing = false
     @State private var retryCount = 0
@@ -59,17 +59,11 @@ struct OnboardingView: View {
 
     private var onboardingBackground: some View {
         ZStack {
-            Color(.systemGroupedBackground)
-            LinearGradient(
-                colors: [Color.userAccentColor.opacity(0.22), .clear, Color.userAccentColor.opacity(0.08)],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            Circle()
-                .fill(Color.userAccentColor.opacity(0.12))
-                .frame(width: horizontalSizeClass == .regular ? 520 : 330)
-                .blur(radius: 2)
-                .offset(x: 160, y: -300)
+            AppBackground()
+
+            CraftifyBlockGlow()
+                .frame(width: horizontalSizeClass == .regular ? 430 : 290)
+                .offset(x: horizontalSizeClass == .regular ? 270 : 165, y: -280)
         }
         .ignoresSafeArea()
     }
@@ -244,8 +238,8 @@ struct OnboardingView: View {
         .frame(maxWidth: 720)
     }
 
-    private var appMark: AppMark {
-        AppMark()
+    private var appMark: CraftifyAppMark {
+        CraftifyAppMark()
     }
 
     private var pagePadding: CGFloat {
@@ -459,22 +453,21 @@ private struct SlidingDoorMask: Shape {
     }
 }
 
-private struct AppMark: View {
-    var size: CGFloat = 88
-
+private struct CraftifyBlockGlow: View {
     var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: size / 4, style: .continuous)
-                .fill(Color.userAccentColor.gradient)
-            Image(systemName: "hammer.fill")
-                .font(.system(size: size * 0.43, weight: .bold))
-                .foregroundStyle(.white)
+        LazyVGrid(
+            columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 3),
+            spacing: 10
+        ) {
+            ForEach(0..<9, id: \.self) { index in
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color.userAccentColor.opacity(index == 4 ? 0.18 : 0.08))
+                    .aspectRatio(1, contentMode: .fit)
+            }
         }
-        .frame(width: size, height: size)
-        .shadow(color: Color.userAccentColor.opacity(0.28), radius: 16, y: 8)
+        .rotationEffect(.degrees(9))
         .accessibilityHidden(true)
     }
-
 }
 
 private struct CraftifyPrimaryButtonStyle: ButtonStyle {

--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import CloudKit
 
 enum SelectedItem: Equatable {
     case grid(index: Int)
@@ -15,70 +14,82 @@ enum SelectedItem: Equatable {
 }
 
 struct RecipeDetailView: View {
-    @EnvironmentObject var dataManager: DataManager
-    @Environment(\.colorScheme) var colorScheme
+    @EnvironmentObject private var dataManager: DataManager
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let recipe: Recipe
     @Binding var navigationPath: NavigationPath
+
     @State private var selectedDetail: String?
     @State private var selectedItem: SelectedItem?
-    @State private var animateHeart: Bool = false
     @State private var showingChestPicker = false
-    @State private var selectedCraftingOption: Int = 0
-    @State private var feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+    @State private var selectedCraftingOption = 0
     @State private var ingredientSets: [[String]] = []
     @State private var outputs: [Int] = []
-    @State private var animateRemark: Bool = false
-    @State private var animateBorder: Bool = false
-    @AppStorage("accentColorPreference") private var accentColorPreference: String = "default"
 
-    private var craftingHeight: CGFloat { horizontalSizeClass == .regular ? 240 : 222 }
-    private var cellSize: CGFloat { horizontalSizeClass == .regular ? 80 : 70 }
+    private var currentIngredients: [String] {
+        guard ingredientSets.indices.contains(selectedCraftingOption) else { return [] }
+        return ingredientSets[selectedCraftingOption]
+    }
+
+    private var currentOutput: Int {
+        guard outputs.indices.contains(selectedCraftingOption) else { return recipe.output }
+        return outputs[selectedCraftingOption]
+    }
 
     var body: some View {
-        ZStack {
-            Color(.systemGroupedBackground)
-                .ignoresSafeArea()
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 20) {
+                RecipeIdentityHeader(recipe: recipe, output: currentOutput)
 
-            RecipeDetailContent(
-                recipe: recipe,
-                navigationPath: $navigationPath,
-                selectedDetail: $selectedDetail,
-                selectedItem: $selectedItem,
-                animateHeart: $animateHeart,
-                selectedCraftingOption: $selectedCraftingOption,
-                feedbackGenerator: feedbackGenerator,
-                ingredientSets: $ingredientSets,
-                outputs: $outputs,
-                animateRemark: $animateRemark,
-                animateBorder: $animateBorder,
-                accentColorPreference: accentColorPreference,
-                craftingHeight: craftingHeight,
-                cellSize: cellSize,
-                horizontalSizeClass: horizontalSizeClass,
-                colorScheme: colorScheme,
-                reduceMotion: reduceMotion,
-                dataManager: dataManager
-            )
+                AlternateRecipesSelector(
+                    ingredientSets: ingredientSets,
+                    selectedCraftingOption: $selectedCraftingOption,
+                    selectedDetail: $selectedDetail,
+                    selectedItem: $selectedItem
+                )
+
+                CraftingRecipeCard(
+                    recipe: recipe,
+                    ingredients: currentIngredients,
+                    output: currentOutput,
+                    selectedItem: $selectedItem,
+                    selectedDetail: $selectedDetail
+                )
+
+                if let selectedDetail {
+                    IngredientDetailPopup(
+                        detail: selectedDetail,
+                        selectedDetail: $selectedDetail,
+                        selectedItem: $selectedItem,
+                        recipe: recipe,
+                        navigationPath: $navigationPath
+                    )
+                    .transition(reduceMotion ? .opacity : .scale(scale: 0.97).combined(with: .opacity))
+                }
+
+                RemarkAndCategoryView(
+                    recipe: recipe,
+                    selectedItem: $selectedItem,
+                    selectedDetail: $selectedDetail
+                )
+            }
+            .craftifyContentWidth(horizontalSizeClass == .regular ? 980 : CraftifyLayout.formMaxWidth)
+            .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+            .padding(.top, 12)
+            .padding(.bottom, 36)
         }
         .navigationTitle(recipe.name)
         .navigationBarTitleDisplayMode(.large)
-        .toolbar(.visible, for: .navigationBar)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Add to Chest", systemImage: "plus") {
                     HapticFeedback.impact()
                     showingChestPicker = true
-                } label: {
-                    Image(systemName: "plus")
-                        .foregroundColor(Color.userAccentColor)
-                        .font(.title2)
                 }
-                .accessibilityLabel("Add recipe to chest")
+                .labelStyle(.iconOnly)
                 .accessibilityHint("Opens your chests")
             }
         }
@@ -86,60 +97,120 @@ struct RecipeDetailView: View {
             AddRecipeToChestView(recipe: recipe)
                 .environmentObject(dataManager)
         }
+        .craftifyPage()
         .onAppear {
-            feedbackGenerator.prepare()
             ingredientSets = computeIngredientSets()
             outputs = computeOutputs()
         }
-        .onChange(of: dataManager.isLoading) { _, newValue in
-            if !newValue && dataManager.isManualSyncing {
-                dataManager.syncChests()
-            }
+        .onChange(of: dataManager.isLoading) { _, isLoading in
+            if !isLoading && dataManager.isManualSyncing { dataManager.syncChests() }
         }
-        .dynamicTypeSize(.xSmall ... .accessibility5)
+        .animation(reduceMotion ? nil : .snappy, value: selectedDetail)
+        .animation(reduceMotion ? nil : .snappy, value: selectedCraftingOption)
     }
 
     private func computeIngredientSets() -> [[String]] {
-        let maxIngredients: Int
-        switch true {
-        case recipe.imageremark == "Furnace":
-            maxIngredients = 2
-        default:
-            maxIngredients = 9
+        let maximum = recipe.imageremark == "Furnace" ? 2 : 9
+        let alternates = [
+            recipe.alternateIngredients,
+            recipe.alternateIngredients1,
+            recipe.alternateIngredients2,
+            recipe.alternateIngredients3
+        ]
+        let allSets = [recipe.ingredients] + alternates.compactMap { ingredients in
+            guard let ingredients, !ingredients.isEmpty else { return nil }
+            return ingredients
         }
-        var sets: [[String]] = [recipe.ingredients]
-        if let alt = recipe.alternateIngredients, !alt.isEmpty {
-            sets.append(alt)
-        }
-        if let alt1 = recipe.alternateIngredients1, !alt1.isEmpty {
-            sets.append(alt1)
-        }
-        if let alt2 = recipe.alternateIngredients2, !alt2.isEmpty {
-            sets.append(alt2)
-        }
-        if let alt3 = recipe.alternateIngredients3, !alt3.isEmpty {
-            sets.append(alt3)
-        }
-        return sets.map { set in
-            set.count < maxIngredients ? set + Array(repeating: "", count: maxIngredients - set.count) : Array(set.prefix(maxIngredients))
+
+        return allSets.map { ingredients in
+            if ingredients.count < maximum {
+                return ingredients + Array(repeating: "", count: maximum - ingredients.count)
+            }
+            return Array(ingredients.prefix(maximum))
         }
     }
 
     private func computeOutputs() -> [Int] {
-        var outputs: [Int] = [recipe.output]
-        if recipe.alternateIngredients != nil {
-            outputs.append(recipe.alternateOutput ?? recipe.output)
+        var result = [recipe.output]
+        if recipe.alternateIngredients?.isEmpty == false { result.append(recipe.alternateOutput ?? recipe.output) }
+        if recipe.alternateIngredients1?.isEmpty == false { result.append(recipe.alternateOutput1 ?? recipe.output) }
+        if recipe.alternateIngredients2?.isEmpty == false { result.append(recipe.alternateOutput2 ?? recipe.output) }
+        if recipe.alternateIngredients3?.isEmpty == false { result.append(recipe.alternateOutput3 ?? recipe.output) }
+        return result
+    }
+}
+
+private struct RecipeIdentityHeader: View {
+    let recipe: Recipe
+    let output: Int
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    var body: some View {
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(spacing: 16) {
+                    recipeImage
+                    details(alignment: .center)
+                }
+            } else {
+                ViewThatFits(in: .horizontal) {
+                    HStack(spacing: 20) {
+                        recipeImage
+                        details(alignment: .leading)
+                    }
+                    VStack(spacing: 16) {
+                        recipeImage
+                        details(alignment: .center)
+                    }
+                }
+            }
         }
-        if recipe.alternateIngredients1 != nil {
-            outputs.append(recipe.alternateOutput1 ?? recipe.output)
+        .padding(20)
+        .frame(maxWidth: .infinity)
+        .craftifyCard(cornerRadius: 26)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(recipe.name), \(recipe.category), crafting output \(output)")
+    }
+
+    private var recipeImage: some View {
+        ZStack {
+            AppBackground()
+            CraftImage(key: recipe.image)
+                .scaledToFit()
+                .padding(16)
         }
-        if recipe.alternateIngredients2 != nil {
-            outputs.append(recipe.alternateOutput2 ?? recipe.output)
+        .frame(width: 112, height: 112)
+        .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .stroke(Color.userAccentColor.opacity(0.24), lineWidth: 1)
         }
-        if let alt3 = recipe.alternateIngredients3, !alt3.isEmpty {
-            outputs.append(recipe.alternateOutput3 ?? recipe.output)
+        .accessibilityHidden(true)
+    }
+
+    private func details(alignment: TextAlignment) -> some View {
+        VStack(alignment: alignment == .center ? .center : .leading, spacing: 7) {
+            Text("CRAFTING RECIPE")
+                .font(.caption.bold())
+                .tracking(1.1)
+                .foregroundStyle(Color.userAccentColor)
+            Text(recipe.name)
+                .font(.largeTitle.bold())
+                .multilineTextAlignment(alignment)
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 8) { metadata }
+                VStack(alignment: alignment == .center ? .center : .leading, spacing: 8) { metadata }
+            }
         }
-        return outputs
+        .frame(maxWidth: .infinity, alignment: alignment == .center ? .center : .leading)
+    }
+
+    @ViewBuilder
+    private var metadata: some View {
+        if !recipe.category.isEmpty {
+            CraftifyStatusPill(title: recipe.category, symbol: "tag.fill")
+        }
+        CraftifyStatusPill(title: "Makes \(output)", symbol: "shippingbox.fill")
     }
 }
 
@@ -154,31 +225,31 @@ private struct AddRecipeToChestView: View {
         NavigationStack {
             List {
                 Section {
-                    Button {
+                    Button("Create New Chest", systemImage: "plus.rectangle.on.folder") {
                         creatingChest = true
-                    } label: {
-                        Label("Create New Chest", systemImage: "plus.rectangle.on.folder")
-                            .fontWeight(.semibold)
                     }
+                    .fontWeight(.semibold)
                 }
+
                 if !dataManager.chests.isEmpty {
-                    Section("Choose a chest") {
+                    Section("Choose a Chest") {
                         ForEach(dataManager.chests) { chest in
                             Button {
-                                if dataManager.add(recipe, to: chest) {
-                                    HapticFeedback.notification(.success)
-                                    dismiss()
-                                } else {
-                                    HapticFeedback.notification(.warning)
-                                    message = chest.recipeIDs.contains(recipe.id)
-                                        ? "This recipe is already in \(chest.name)."
-                                        : "\(chest.name) is full."
-                                }
+                                add(to: chest)
                             } label: {
-                                HStack {
-                                    Label(chest.name, systemImage: chest.displaySymbol)
-                                    Spacer()
+                                HStack(spacing: 12) {
+                                    Image(systemName: chest.displaySymbol)
+                                        .foregroundStyle(Color.userAccentColor)
+                                    VStack(alignment: .leading, spacing: 3) {
+                                        Text(chest.name).foregroundStyle(.primary)
+                                        ProgressView(
+                                            value: Double(chest.recipeIDs.count),
+                                            total: Double(chest.size.rawValue)
+                                        )
+                                        .tint(Color.userAccentColor)
+                                    }
                                     Text("\(chest.recipeIDs.count)/\(chest.size.rawValue)")
+                                        .font(.caption.monospacedDigit())
                                         .foregroundStyle(.secondary)
                                 }
                             }
@@ -188,105 +259,47 @@ private struct AddRecipeToChestView: View {
                     }
                 }
             }
+            .scrollContentBackground(.hidden)
             .navigationTitle("Store \(recipe.name)")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbar { ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } } }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
             .sheet(isPresented: $creatingChest) {
                 ChestEditorView(context: .new, recipeToAdd: recipe) {
                     creatingChest = false
                     dismiss()
                 }
-                    .environmentObject(dataManager)
-                    .presentationDetents([.medium])
-                    .presentationSizing(.page)
+                .environmentObject(dataManager)
+                .presentationDetents([.medium])
+                .presentationSizing(.page)
             }
-            .alert("Couldn’t Add Recipe", isPresented: Binding(get: { message != nil }, set: { if !$0 { message = nil } })) {
+            .alert("Couldn’t Add Recipe", isPresented: messageBinding) {
                 Button("OK", role: .cancel) { message = nil }
-            } message: { Text(message ?? "Please try another chest.") }
+            } message: {
+                Text(message ?? "Please try another chest.")
+            }
+            .craftifyPage()
         }
         .presentationDetents([.medium, .large])
     }
-}
 
-struct RecipeDetailContent: View {
-    let recipe: Recipe
-    @Binding var navigationPath: NavigationPath
-    @Binding var selectedDetail: String?
-    @Binding var selectedItem: SelectedItem?
-    @Binding var animateHeart: Bool
-    @Binding var selectedCraftingOption: Int
-    let feedbackGenerator: UIImpactFeedbackGenerator
-    @Binding var ingredientSets: [[String]]
-    @Binding var outputs: [Int]
-    @Binding var animateRemark: Bool
-    @Binding var animateBorder: Bool
-    let accentColorPreference: String
-    let craftingHeight: CGFloat
-    let cellSize: CGFloat
-    let horizontalSizeClass: UserInterfaceSizeClass?
-    let colorScheme: ColorScheme
-    let reduceMotion: Bool
-    let dataManager: DataManager
+    private var messageBinding: Binding<Bool> {
+        Binding(get: { message != nil }, set: { if !$0 { message = nil } })
+    }
 
-    var body: some View {
-        ScrollView {
-            VStack(spacing: horizontalSizeClass == .regular ? 24 : 20) {
-                AlternateRecipesSelector(
-                    ingredientSets: ingredientSets,
-                    selectedCraftingOption: $selectedCraftingOption,
-                    selectedDetail: $selectedDetail,
-                    selectedItem: $selectedItem,
-                    horizontalSizeClass: horizontalSizeClass
-                )
-
-                GridView(
-                    recipe: recipe,
-                    selectedItem: $selectedItem,
-                    selectedDetail: $selectedDetail,
-                    craftingHeight: craftingHeight,
-                    ingredients: ingredientSets.isEmpty ? [] : ingredientSets[selectedCraftingOption],
-                    output: outputs.isEmpty ? recipe.output : outputs[selectedCraftingOption],
-                    selectedCraftingOption: selectedCraftingOption,
-                    accentColorPreference: accentColorPreference
-                )
-                .padding(.bottom, horizontalSizeClass == .regular ? 24 : 16)
-
-                if let detail = selectedDetail {
-                    IngredientDetailPopup(
-                        detail: detail,
-                        selectedDetail: $selectedDetail,
-                        selectedItem: $selectedItem,
-                        recipe: recipe,
-                        navigationPath: $navigationPath,
-                        feedbackGenerator: feedbackGenerator,
-                        horizontalSizeClass: horizontalSizeClass,
-                        colorScheme: colorScheme
-                    )
-                    .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
-                    .padding(.bottom, horizontalSizeClass == .regular ? 24 : 16)
-                }
-
-                RemarkAndCategoryView(
-                    recipe: recipe,
-                    selectedItem: $selectedItem,
-                    selectedDetail: $selectedDetail,
-                    animateRemark: $animateRemark,
-                    animateBorder: $animateBorder,
-                    feedbackGenerator: feedbackGenerator,
-                    horizontalSizeClass: horizontalSizeClass,
-                    reduceMotion: reduceMotion
-                )
-                .padding(.top, 16)
-                .padding(.bottom, 16)
-            }
-            .padding(.vertical, 16)
-            .padding(.bottom, 50)
+    private func add(to chest: RecipeChest) {
+        if dataManager.add(recipe, to: chest) {
+            HapticFeedback.notification(.success)
+            dismiss()
+        } else {
+            HapticFeedback.notification(.warning)
+            message = chest.recipeIDs.contains(recipe.id)
+                ? "This recipe is already in \(chest.name)."
+                : "\(chest.name) is full."
         }
-        .id(accentColorPreference)
-        .safeAreaInset(edge: .top, content: { Color.clear.frame(height: 0) })
-        .safeAreaInset(edge: .bottom, content: { Color.clear.frame(height: 0) })
-        .background(Color(.systemGroupedBackground))
-        .accessibilityElement(children: .contain)
     }
 }
 
@@ -295,50 +308,155 @@ struct AlternateRecipesSelector: View {
     @Binding var selectedCraftingOption: Int
     @Binding var selectedDetail: String?
     @Binding var selectedItem: SelectedItem?
-    let horizontalSizeClass: UserInterfaceSizeClass?
 
     var body: some View {
-        if ingredientSets.count <= 1 {
-            Text("No alternate crafting options available")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
-                .padding(.top, 8)
-                .frame(maxWidth: .infinity, alignment: .center)
-                .accessibilityLabel("No alternate crafting options")
-        } else {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
-                    ForEach(0..<ingredientSets.count, id: \.self) { index in
-                        Button {
-                            HapticFeedback.impact()
-                            withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+        if ingredientSets.count > 1 {
+            VStack(alignment: .leading, spacing: 10) {
+                CraftifySectionHeader(
+                    title: "Crafting Options",
+                    detail: "Choose an ingredient combination."
+                )
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(ingredientSets.indices, id: \.self) { index in
+                            let isSelected = selectedCraftingOption == index
+                            Button("Option \(index + 1)") {
                                 selectedCraftingOption = index
                                 selectedDetail = nil
                                 selectedItem = nil
+                                HapticFeedback.selection()
                             }
-                        } label: {
-                            Text("Recipe \(index + 1)")
-                                .fontWeight(.bold)
-                                .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
-                                .padding(.vertical, 8)
-                                .background(selectedCraftingOption == index ? Color.userAccentColor : Color.gray.opacity(0.2))
-                                .foregroundStyle(selectedCraftingOption == index ? Color.white : Color.primary)
-                                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(isSelected ? Color.white : Color.primary)
+                            .padding(.horizontal, 15)
+                            .padding(.vertical, 9)
+                            .background(
+                                isSelected ? Color.userAccentColor : Color.primary.opacity(0.06),
+                                in: Capsule()
+                            )
+                            .buttonStyle(.plain)
+                            .accessibilityValue(isSelected ? "Selected" : "Not selected")
                         }
-                        .accessibilityLabel("Recipe \(index + 1)")
-                        .accessibilityHint("Selects ingredient combination \(index + 1)")
                     }
+                    .padding(.vertical, 2)
                 }
-                .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
-                .padding(.top, 8)
-                .padding(.bottom, 8)
             }
-            .frame(maxWidth: .infinity, minHeight: 44)
-            .accessibilityElement(children: .contain)
-            .accessibilityLabel("Crafting options")
-            .accessibilityHint("Select different ingredient combinations")
+            .padding(18)
+            .craftifyCard(cornerRadius: 22)
         }
+    }
+}
+
+private struct CraftingRecipeCard: View {
+    let recipe: Recipe
+    let ingredients: [String]
+    let output: Int
+    @Binding var selectedItem: SelectedItem?
+    @Binding var selectedDetail: String?
+
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private var cellSize: CGFloat {
+        horizontalSizeClass == .regular ? 76 : 64
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            CraftifySectionHeader(
+                title: recipe.imageremark == "Furnace" ? "Smelting Layout" : "Crafting Layout",
+                detail: "Tap an ingredient or the output to inspect it.",
+                symbol: recipe.imageremark == "Furnace" ? "flame.fill" : "square.grid.3x3.fill"
+            )
+
+            if dynamicTypeSize.isAccessibilitySize {
+                verticalLayout
+            } else {
+                ViewThatFits(in: .horizontal) {
+                    horizontalLayout
+                    verticalLayout
+                }
+            }
+        }
+        .padding(20)
+        .craftifyCard(cornerRadius: 24)
+    }
+
+    private var horizontalLayout: some View {
+        HStack(spacing: horizontalSizeClass == .regular ? 28 : 20) {
+            craftingGrid
+            Image(systemName: "arrow.right")
+                .font(.title.bold())
+                .foregroundStyle(Color.userAccentColor)
+                .accessibilityHidden(true)
+            outputTile
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var verticalLayout: some View {
+        VStack(spacing: 15) {
+            craftingGrid
+            Image(systemName: "arrow.down")
+                .font(.title2.bold())
+                .foregroundStyle(Color.userAccentColor)
+                .accessibilityHidden(true)
+            outputTile
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private var craftingGrid: some View {
+        if recipe.imageremark == "Furnace" {
+            FurnaceGridView(
+                ingredients: ingredients,
+                selectedItem: $selectedItem,
+                selectedDetail: $selectedDetail,
+                cellSize: cellSize
+            )
+        } else {
+            DefaultGridView(
+                ingredients: ingredients,
+                selectedItem: $selectedItem,
+                selectedDetail: $selectedDetail,
+                cellSize: cellSize
+            )
+        }
+    }
+
+    private var outputTile: some View {
+        Button {
+            selectedDetail = recipe.name
+            selectedItem = .output
+            HapticFeedback.impact()
+        } label: {
+            VStack(spacing: 7) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 15, style: .continuous)
+                        .fill(Color.userAccentColor.opacity(0.09))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 15, style: .continuous)
+                                .stroke(
+                                    selectedItem == .output ? Color.userAccentColor : Color.userAccentColor.opacity(0.18),
+                                    lineWidth: selectedItem == .output ? 2 : 1
+                                )
+                        }
+                    CraftImage(key: recipe.image)
+                        .scaledToFit()
+                        .padding(9)
+                }
+                .frame(width: cellSize + 12, height: cellSize + 12)
+
+                Text("×\(output)")
+                    .font(.headline.monospacedDigit())
+                    .foregroundStyle(.primary)
+            }
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Output: \(recipe.name), quantity \(output)")
+        .accessibilityHint("Shows output details")
     }
 }
 
@@ -348,109 +466,62 @@ struct IngredientDetailPopup: View {
     @Binding var selectedItem: SelectedItem?
     let recipe: Recipe
     @Binding var navigationPath: NavigationPath
-    let feedbackGenerator: UIImpactFeedbackGenerator
-    let horizontalSizeClass: UserInterfaceSizeClass?
-    let colorScheme: ColorScheme
-    @EnvironmentObject var dataManager: DataManager
+    @EnvironmentObject private var dataManager: DataManager
+
+    private var subRecipe: Recipe? {
+        guard case .grid = selectedItem else { return nil }
+        return dataManager.recipes.first { $0.name == detail }
+    }
+
+    private var descriptor: String {
+        switch selectedItem {
+        case .output: "Crafting output"
+        case .imageremark: recipe.remarks?.isEmpty == false ? recipe.remarks! : "Crafting utility"
+        case .grid: "Crafting ingredient"
+        case nil: "Recipe detail"
+        }
+    }
 
     var body: some View {
-        ZStack(alignment: .topTrailing) {
-            VStack(spacing: 8) {
+        VStack(spacing: 16) {
+            HStack(alignment: .top, spacing: 14) {
                 CraftImage(key: detail)
                     .scaledToFit()
-                    .frame(width: horizontalSizeClass == .regular ? 90 : 80, height: horizontalSizeClass == .regular ? 90 : 80)
+                    .frame(width: 76, height: 76)
                     .padding(8)
-                    .background(Color(.systemGray5))
-                    .cornerRadius(12)
-                    .accessibilityLabel("Image of \(detail)")
-                Text(detail)
-                    .font(.title2)
-                    .fontWeight(.bold)
-                    .foregroundColor(.primary)
-                    .padding(.horizontal, 8)
-                    .lineLimit(2)
-                    .minimumScaleFactor(0.8)
-                    .accessibilityLabel(detail)
+                    .background(Color.userAccentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .accessibilityHidden(true)
 
-                Text(
-                    selectedItem == .imageremark
-                        ? (recipe.remarks?.isEmpty == false ? recipe.remarks! : "No remarks available")
-                        : (detail == recipe.name ? "Output of crafting" : "Ingredient for crafting")
-                )
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal, 8)
-                    .lineLimit(3)
-                    .minimumScaleFactor(0.8)
-                    .accessibilityLabel(
-                        selectedItem == .imageremark
-                            ? "Remark"
-                            : (detail == recipe.name ? "Output" : "Ingredient")
-                    )
-                    .accessibilityValue(
-                        selectedItem == .imageremark
-                            ? (recipe.remarks?.isEmpty == false ? recipe.remarks! : "No remarks available")
-                            : (detail == recipe.name ? recipe.name : "Ingredient for crafting")
-                    )
-
-                if let selectedItem = selectedItem, case .grid(_) = selectedItem, !detail.isEmpty && dataManager.recipes.contains(where: { $0.name == detail }) {
-                    Button {
-                        if let subRecipe = dataManager.recipes.first(where: { $0.name == detail }) {
-                            navigationPath.append(subRecipe)
-                        }
-                    } label: {
-                        HStack {
-                            Image(systemName: "info.circle")
-                            Text("View Recipe")
-                        }
+                VStack(alignment: .leading, spacing: 5) {
+                    Text(detail)
+                        .font(.title2.bold())
+                    Text(descriptor)
                         .font(.subheadline)
-                        .foregroundColor(Color.userAccentColor)
-                    }
-                    .accessibilityLabel("View recipe for \(detail)")
-                    .accessibilityHint("Opens the crafting recipe for this ingredient")
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-            }
-            .padding(.vertical, 12)
-            .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
-            .frame(maxWidth: .infinity)
-            .background(
-                ZStack {
-                    Color(.systemGray5)
-                    RoundedRectangle(cornerRadius: 16)
-                        .stroke(Color.userAccentColor, lineWidth: 2)
-                }
-                .clipShape(RoundedRectangle(cornerRadius: 16))
-                .shadow(
-                    color: colorScheme == .light ? .black.opacity(0.15) : .black.opacity(0.3),
-                    radius: colorScheme == .light ? 6 : 8
-                )
-            )
-
-            Button {
-                feedbackGenerator.impactOccurred()
-                feedbackGenerator.prepare()
-                withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
+                Spacer(minLength: 4)
+                Button("Close", systemImage: "xmark.circle.fill") {
                     selectedDetail = nil
                     selectedItem = nil
+                    HapticFeedback.impact(.light)
                 }
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundColor(Color.userAccentColor)
-                    .background(
-                        Circle()
-                            .fill(Color(.systemGray5))
-                            .frame(width: 24, height: 24)
-                            .shadow(radius: 2)
-                    )
-                    .frame(width: 24, height: 24)
+                .labelStyle(.iconOnly)
+                .font(.title2)
+                .accessibilityHint("Dismisses these details")
             }
-            .padding(.top, 4)
-            .padding(.trailing, 4)
-            .accessibilityLabel("Close popup")
-            .accessibilityHint("Dismisses the details")
+
+            if let subRecipe {
+                Button("View \(subRecipe.name) Recipe", systemImage: "arrow.right.circle.fill") {
+                    navigationPath.append(subRecipe)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
         }
-        .transition(.scale)
-        .animation(.spring(response: 0.3, dampingFraction: 0.5), value: selectedDetail)
+        .padding(18)
+        .craftifyCard(cornerRadius: 22)
         .accessibilityElement(children: .contain)
     }
 }
@@ -459,167 +530,60 @@ struct RemarkAndCategoryView: View {
     let recipe: Recipe
     @Binding var selectedItem: SelectedItem?
     @Binding var selectedDetail: String?
-    @Binding var animateRemark: Bool
-    @Binding var animateBorder: Bool
-    let feedbackGenerator: UIImpactFeedbackGenerator
-    let horizontalSizeClass: UserInterfaceSizeClass?
-    let reduceMotion: Bool
 
     var body: some View {
-        VStack(spacing: 8) {
-            if recipe.imageremark?.isEmpty == false {
+        if recipe.imageremark?.isEmpty == false || recipe.remarks?.isEmpty == false {
+            VStack(alignment: .leading, spacing: 15) {
+                CraftifySectionHeader(
+                    title: "Crafting Notes",
+                    detail: "Extra context for this recipe.",
+                    symbol: "lightbulb.fill"
+                )
+
                 if let imageRemark = recipe.imageremark, !imageRemark.isEmpty {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(Color(.systemGray5))
-                            .frame(width: horizontalSizeClass == .regular ? 45 : 40, height: horizontalSizeClass == .regular ? 45 : 40)
-                            .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
-                            .overlay(
-                                ZStack {
-                                    if selectedItem == .imageremark {
-                                        RoundedRectangle(cornerRadius: 8)
-                                            .stroke(Color.userAccentColor, lineWidth: 2)
-                                            .shadow(radius: 4)
-                                    } else {
-                                        RoundedRectangle(cornerRadius: 8)
-                                            .stroke(Color.userAccentColor.opacity(animateBorder ? 1.0 : 0.0), lineWidth: 2)
-                                    }
-                                }
-                            )
-                        CraftImage(key: imageRemark)
-                            .scaledToFit()
-                            .frame(width: horizontalSizeClass == .regular ? 28 : 24, height: horizontalSizeClass == .regular ? 28 : 24)
-                    }
-                    .scaleEffect(animateRemark ? 1.15 : 1.0)
-                    .accessibilityLabel("Remark image")
-                    .accessibilityHint("Tap to view remarks")
-                    .onTapGesture {
-                        feedbackGenerator.impactOccurred()
-                        feedbackGenerator.prepare()
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
-                            selectedDetail = imageRemark
-                            selectedItem = .imageremark
+                    Button {
+                        selectedDetail = imageRemark
+                        selectedItem = .imageremark
+                        HapticFeedback.impact()
+                    } label: {
+                        HStack(spacing: 13) {
+                            CraftImage(key: imageRemark)
+                                .scaledToFit()
+                                .frame(width: 48, height: 48)
+                                .padding(5)
+                                .background(Color.userAccentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                                .accessibilityHidden(true)
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(imageRemark)
+                                    .font(.headline)
+                                    .foregroundStyle(.primary)
+                                Text("Required crafting utility")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Image(systemName: "info.circle.fill")
+                                .foregroundStyle(Color.userAccentColor)
+                                .accessibilityHidden(true)
                         }
+                        .padding(12)
+                        .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 15, style: .continuous))
                     }
-                    .onAppear {
-                        guard !reduceMotion else { return }
-                        withAnimation(.spring(response: 0.6, dampingFraction: 0.7).repeatCount(3, autoreverses: true)) {
-                            animateRemark = true
-                            animateBorder = true
-                        }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) {
-                            animateRemark = false
-                            animateBorder = false
-                        }
-                    }
-                }
-            }
-
-            if !recipe.category.isEmpty {
-                Text("Category: \(recipe.category)")
-                    .font(.subheadline)
-                    .foregroundColor(.primary)
-                    .padding(.vertical, 10)
-                    .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
-                    .background(
-                        Color(.systemGray5)
-                            .clipShape(RoundedRectangle(cornerRadius: 16))
-                    )
-                    .accessibilityLabel("Category: \(recipe.category)")
-            }
-        }
-    }
-}
-
-struct GridView: View {
-    let recipe: Recipe
-    @Binding var selectedItem: SelectedItem?
-    @Binding var selectedDetail: String?
-    let craftingHeight: CGFloat
-    let ingredients: [String]
-    let output: Int
-    let selectedCraftingOption: Int
-    let accentColorPreference: String
-    @State private var feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-
-    var body: some View {
-        VStack {
-            HStack(alignment: .center, spacing: 16) {
-                if recipe.imageremark == "Furnace" {
-                    FurnaceGridView(
-                        ingredients: ingredients,
-                        selectedItem: $selectedItem,
-                        selectedDetail: $selectedDetail,
-                        feedbackGenerator: feedbackGenerator,
-                        cellSize: horizontalSizeClass == .regular ? 80 : 70,
-                        accentColorPreference: accentColorPreference
-                    )
-                    .frame(width: craftingHeight, height: craftingHeight)
-                } else {
-                    DefaultGridView(
-                        ingredients: ingredients,
-                        selectedItem: $selectedItem,
-                        selectedDetail: $selectedDetail,
-                        feedbackGenerator: feedbackGenerator,
-                        cellSize: horizontalSizeClass == .regular ? 80 : 70,
-                        accentColorPreference: accentColorPreference
-                    )
-                    .frame(width: craftingHeight, height: craftingHeight)
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Crafting utility: \(imageRemark)")
+                    .accessibilityHint("Shows crafting notes")
                 }
 
-                Image(systemName: "arrow.right")
-                    .font(.largeTitle)
-                    .foregroundColor(.gray)
-                    .frame(width: horizontalSizeClass == .regular ? 45 : 40, height: craftingHeight)
-                    .accessibilityHidden(true)
-
-                VStack {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(Color(.systemGray5))
-                            .frame(width: horizontalSizeClass == .regular ? 80 : 70, height: horizontalSizeClass == .regular ? 80 : 70)
-                            .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
-                            .overlay(
-                                selectedItem == .output
-                                ? RoundedRectangle(cornerRadius: 12)
-                                    .stroke(Color.userAccentColor, lineWidth: 2)
-                                    .shadow(radius: 4)
-                                : nil
-                            )
-
-                        CraftImage(key: recipe.image)
-                            .scaledToFit()
-                            .frame(width: horizontalSizeClass == .regular ? 70 : 60, height: horizontalSizeClass == .regular ? 70 : 60)
-                    }
-                    .accessibilityLabel("Output: \(recipe.name)")
-                    .accessibilityHint("Tap to view details")
-                    .onTapGesture {
-                        feedbackGenerator.impactOccurred()
-                        feedbackGenerator.prepare()
-                        withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
-                            selectedDetail = recipe.name
-                            selectedItem = .output
-                        }
-                    }
-
-                    Text("x\(output)")
-                        .font(.headline)
-                        .foregroundColor(.primary)
-                        .accessibilityLabel("Output quantity: \(output)")
+                if let remarks = recipe.remarks, !remarks.isEmpty {
+                    Text(remarks)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-                .frame(height: craftingHeight)
             }
-            .frame(maxWidth: .infinity, alignment: .center)
-            .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
+            .padding(18)
+            .craftifyCard(cornerRadius: 22)
         }
-        .frame(height: craftingHeight)
-        .animation(.spring(response: 0.3, dampingFraction: 0.5), value: selectedCraftingOption)
-        .onAppear {
-            feedbackGenerator.prepare()
-        }
-        .dynamicTypeSize(.xSmall ... .accessibility5)
     }
 }
 
@@ -627,51 +591,32 @@ struct FurnaceGridView: View {
     let ingredients: [String]
     @Binding var selectedItem: SelectedItem?
     @Binding var selectedDetail: String?
-    let feedbackGenerator: UIImpactFeedbackGenerator
     let cellSize: CGFloat
-    let accentColorPreference: String
-    @EnvironmentObject var dataManager: DataManager
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
         VStack(spacing: 6) {
-            HStack {
-                Spacer()
-                GridCell(
-                    index: 0,
-                    ingredient: ingredients.count > 0 ? ingredients[0] : "",
-                    isSelected: selectedItem == .grid(index: 0),
-                    feedbackGenerator: feedbackGenerator,
-                    cellSize: cellSize,
-                    accentColorPreference: accentColorPreference
-                ) { selectedDetail = ingredients.count > 0 ? ingredients[0] : ""; selectedItem = .grid(index: 0) }
-                Spacer()
-            }
-            HStack {
-                Spacer()
-                Image(UIImage(named: "Furnace Fire") != nil ? "Furnace Fire" : "photo")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: cellSize - 35, height: cellSize - 35)
-                    .frame(width: cellSize, height: cellSize)
-                    .accessibilityLabel("Furnace Fire slot")
-                    .accessibilityHint("Represents the furnace")
-                Spacer()
-            }
-            HStack {
-                Spacer()
-                GridCell(
-                    index: 1,
-                    ingredient: ingredients.count > 1 ? ingredients[1] : "",
-                    isSelected: selectedItem == .grid(index: 1),
-                    feedbackGenerator: feedbackGenerator,
-                    cellSize: cellSize,
-                    accentColorPreference: accentColorPreference
-                ) { selectedDetail = ingredients.count > 1 ? ingredients[1] : ""; selectedItem = .grid(index: 1) }
-                Spacer()
-            }
+            ingredientCell(index: 0)
+            Image("Furnace Fire")
+                .resizable()
+                .scaledToFit()
+                .padding(cellSize * 0.28)
+                .frame(width: cellSize, height: cellSize)
+                .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .accessibilityLabel("Furnace fire")
+            ingredientCell(index: 1)
         }
-        .dynamicTypeSize(.xSmall ... .accessibility5)
+    }
+
+    private func ingredientCell(index: Int) -> some View {
+        GridCell(
+            index: index,
+            ingredient: ingredients.indices.contains(index) ? ingredients[index] : "",
+            isSelected: selectedItem == .grid(index: index),
+            cellSize: cellSize
+        ) {
+            selectedDetail = ingredients[index]
+            selectedItem = .grid(index: index)
+        }
     }
 }
 
@@ -679,31 +624,27 @@ struct DefaultGridView: View {
     let ingredients: [String]
     @Binding var selectedItem: SelectedItem?
     @Binding var selectedDetail: String?
-    let feedbackGenerator: UIImpactFeedbackGenerator
     let cellSize: CGFloat
-    let accentColorPreference: String
-    @EnvironmentObject var dataManager: DataManager
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
         VStack(spacing: 6) {
             ForEach(0..<3) { row in
                 HStack(spacing: 6) {
-                    ForEach(0..<3) { col in
-                        let index = row * 3 + col
+                    ForEach(0..<3) { column in
+                        let index = row * 3 + column
                         GridCell(
                             index: index,
-                            ingredient: index < ingredients.count ? ingredients[index] : "",
+                            ingredient: ingredients.indices.contains(index) ? ingredients[index] : "",
                             isSelected: selectedItem == .grid(index: index),
-                            feedbackGenerator: feedbackGenerator,
-                            cellSize: cellSize,
-                            accentColorPreference: accentColorPreference
-                        ) { selectedDetail = index < ingredients.count ? ingredients[index] : ""; selectedItem = .grid(index: index) }
+                            cellSize: cellSize
+                        ) {
+                            selectedDetail = ingredients[index]
+                            selectedItem = .grid(index: index)
+                        }
                     }
                 }
             }
         }
-        .dynamicTypeSize(.xSmall ... .accessibility5)
     }
 }
 
@@ -711,42 +652,37 @@ struct GridCell: View {
     let index: Int
     let ingredient: String
     let isSelected: Bool
-    let feedbackGenerator: UIImpactFeedbackGenerator
     let cellSize: CGFloat
-    let accentColorPreference: String
     let onTap: () -> Void
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 12)
-                .fill(!ingredient.isEmpty ? Color(.systemGray5) : Color(.systemGray6))
-                .frame(width: cellSize, height: cellSize)
-                .shadow(color: .black.opacity(0.1), radius: 4, x: 0, y: 2)
-                .overlay(
-                    isSelected
-                    ? RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color.userAccentColor, lineWidth: 2)
-                        .shadow(radius: 4)
-                    : nil
-                )
-
-            if !ingredient.isEmpty {
-                CraftImage(key: ingredient)
-                    .scaledToFit()
-                    .frame(width: cellSize - 10, height: cellSize - 10)
-            }
-        }
-        .accessibilityLabel(!ingredient.isEmpty ? "Ingredient: \(ingredient)" : "Empty slot")
-        .accessibilityHint(!ingredient.isEmpty ? "Tap to view details" : "")
-        .onTapGesture {
+        Button {
             guard !ingredient.isEmpty else { return }
-            feedbackGenerator.impactOccurred()
-            feedbackGenerator.prepare()
-            withAnimation(.spring(response: 0.3, dampingFraction: 0.5)) {
-                onTap()
+            HapticFeedback.impact()
+            onTap()
+        } label: {
+            ZStack {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(ingredient.isEmpty ? Color.primary.opacity(0.035) : Color.userAccentColor.opacity(0.075))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                            .stroke(
+                                isSelected ? Color.userAccentColor : Color.primary.opacity(ingredient.isEmpty ? 0.05 : 0.10),
+                                lineWidth: isSelected ? 2 : 1
+                            )
+                    }
+
+                if !ingredient.isEmpty {
+                    CraftImage(key: ingredient)
+                        .scaledToFit()
+                        .padding(7)
+                }
             }
+            .frame(width: cellSize, height: cellSize)
         }
-        .dynamicTypeSize(.xSmall ... .accessibility5)
+        .buttonStyle(.plain)
+        .disabled(ingredient.isEmpty)
+        .accessibilityLabel(ingredient.isEmpty ? "Empty crafting slot" : "Ingredient: \(ingredient)")
+        .accessibilityHint(ingredient.isEmpty ? "" : "Shows ingredient details")
     }
 }

--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -469,7 +469,7 @@ struct IngredientDetailPopup: View {
     @EnvironmentObject private var dataManager: DataManager
 
     private var subRecipe: Recipe? {
-        guard case .grid = selectedItem else { return nil }
+        guard case .grid(_) = selectedItem else { return nil }
         return dataManager.recipes.first { $0.name == detail }
     }
 

--- a/Craftify/RecipeSearchView.swift
+++ b/Craftify/RecipeSearchView.swift
@@ -144,7 +144,7 @@ struct RecipeSearchView: View {
 
             if recentSearchRecipes.isEmpty {
                 searchState(
-                    symbol: "sparkle.magnifyingglass",
+                    symbol: "magnifyingglass.circle.fill",
                     title: "What Are You Crafting?",
                     detail: "Tap the search field and start with a recipe name or ingredient."
                 )

--- a/Craftify/RecipeSearchView.swift
+++ b/Craftify/RecipeSearchView.swift
@@ -6,15 +6,11 @@
 //
 
 import SwiftUI
-import UIKit
-import Combine
-import CloudKit
 
 struct RecipeSearchView: View {
     @EnvironmentObject private var dataManager: DataManager
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @AppStorage("accentColorPreference") private var accentColorPreference: String = "default"
     @State private var searchText = ""
     @State private var isSearchActive = false
     @State private var filteredRecipes: [String: [Recipe]] = [:]
@@ -27,225 +23,72 @@ struct RecipeSearchView: View {
         case ingredients = "Ingredients"
 
         var id: Self { self }
+        var symbol: String {
+            switch self {
+            case .all: "text.magnifyingglass"
+            case .names: "character.cursor.ibeam"
+            case .ingredients: "cube.fill"
+            }
+        }
     }
 
-    // Resolve synced history names to recipes available on this device.
     private var recentSearchRecipes: [Recipe] {
-        var recipes: [Recipe] = []
+        var resolved: [Recipe] = []
         for name in dataManager.recentSearchNames {
             if let recipe = dataManager.recipes.first(where: { $0.name == name }),
-               !recipes.contains(where: { $0.name == name }) {
-                recipes.append(recipe)
-            } else {
-                print("Skipping invalid recent search name: \(name) - no matching recipe found")
+               !resolved.contains(where: { $0.id == recipe.id }) {
+                resolved.append(recipe)
             }
         }
-        return Array(recipes.prefix(10))
+        return Array(resolved.prefix(10))
     }
 
-    // Save a new recent search using DataManager
-    private func saveRecentSearch(_ recipe: Recipe) {
-        dataManager.saveRecentSearch(recipe)
-    }
-
-    // Clear all recent searches using DataManager
-    private func clearRecentSearches() {
-        dataManager.clearRecentSearches()
-    }
-
-    private func updateFilteredRecipes() {
-        let filtered = searchText.isEmpty ? dataManager.recipes :
-            dataManager.recipes.filter { recipe in
-                switch searchFilter {
-                case .all:
-                    return recipe.name.localizedCaseInsensitiveContains(searchText)
-                        || recipe.ingredients.contains { $0.localizedCaseInsensitiveContains(searchText) }
-                case .names:
-                    return recipe.name.localizedCaseInsensitiveContains(searchText)
-                case .ingredients:
-                    return recipe.ingredients.contains { $0.localizedCaseInsensitiveContains(searchText) }
-                }
-            }
-
-        var groups = [String: [Recipe]]()
-        for recipe in filtered {
-            let key = String(recipe.name.prefix(1).uppercased())
-            groups[key, default: []].append(recipe)
-        }
-        for key in groups.keys {
-            groups[key]?.sort(by: { $0.name < $1.name })
-        }
-        filteredRecipes = groups
+    private var resultColumns: [GridItem] {
+        CraftifyLayout.adaptiveColumns(
+            minimum: dynamicTypeSize.isAccessibilitySize ? 300 : 320,
+            maximum: 520,
+            spacing: 14,
+            dynamicTypeSize: dynamicTypeSize
+        )
     }
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
             ScrollView {
-                LazyVStack(spacing: 0) {
+                LazyVStack(alignment: .leading, spacing: 24) {
                     if searchText.isEmpty && !isSearchActive {
-                        // Initial state when not searching
-                        if recentSearchRecipes.isEmpty {
-                            // No recent searches
-                            VStack(spacing: 16) {
-                                Image(systemName: "magnifyingglass")
-                                    .font(.system(size: 48))
-                                    .foregroundColor(Color.userAccentColor.opacity(0.8))
-                                Text("Search for Recipes")
-                                    .font(.title2)
-                                    .fontWeight(.bold)
-                                    .foregroundColor(.primary)
-                                Text("Find recipes by name or ingredients.")
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                                    .multilineTextAlignment(.center)
-                                    .padding(.horizontal, horizontalSizeClass == .regular ? 48 : 32)
-                            }
-                            .padding(.vertical, 16)
-                            .accessibilityElement(children: .combine)
-                            .accessibilityLabel("Search for Recipes")
-                            .accessibilityHint("Enter a search term to find recipes by name or ingredients")
-                        } else {
-                            // Show recent searches
-                            VStack(alignment: .leading, spacing: 8) {
-                                HStack {
-                                    Text("Recent Searches")
-                                        .font(.title3)
-                                        .fontWeight(.bold)
-                                        .foregroundColor(.primary)
-
-                                    Spacer()
-
-                                    Button(action: {
-                                        clearRecentSearches()
-                                        HapticFeedback.impact(.medium)
-                                    }) {
-                                        Text("Clear All")
-                                            .font(.subheadline)
-                                            .foregroundColor(Color.userAccentColor)
-                                    }
-                                    .disabled(recentSearchRecipes.isEmpty)
-                                    .contentShape(Rectangle())
-                                    .accessibilityLabel("Clear All Recent Searches")
-                                    .accessibilityHint("Removes all recent search history")
-                                }
-                                .padding(.horizontal, 16)
-                                .padding(.top, 8)
-                                .padding(.bottom, 4)
-                                .background(Color(.systemGroupedBackground))
-                                .id(accentColorPreference)
-
-                                RecentSearchesList(
-                                    recipes: recentSearchRecipes,
-                                    navigationPath: $navigationPath,
-                                    accentColorPreference: accentColorPreference
-                                )
-                            }
-                            .padding(.vertical, 16)
-                            .accessibilityElement(children: .combine)
-                            .accessibilityLabel("Recent Searches")
-                            .accessibilityHint("Shows the last 10 recipes you opened from search")
-                        }
+                        inactiveContent
+                    } else if searchText.isEmpty {
+                        searchState(
+                            symbol: "text.cursor",
+                            title: "Start Searching",
+                            detail: "Enter a recipe name or an ingredient you already have."
+                        )
+                    } else if filteredRecipes.isEmpty {
+                        searchState(
+                            symbol: "magnifyingglass",
+                            title: "No Recipes Found",
+                            detail: "Try another term or change where Craftify searches."
+                        )
                     } else {
-                        if searchText.isEmpty {
-                            // Show placeholder when search bar is tapped but no text is entered
-                            VStack(spacing: 16) {
-                                Image(systemName: "magnifyingglass")
-                                    .font(.system(size: 48))
-                                    .foregroundColor(Color.userAccentColor.opacity(0.8))
-                                Text("Start Searching")
-                                    .font(.title2)
-                                    .fontWeight(.bold)
-                                    .foregroundColor(.primary)
-                                Text("Enter a recipe name or ingredient to start searching.")
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                                    .multilineTextAlignment(.center)
-                                    .padding(.horizontal, horizontalSizeClass == .regular ? 48 : 32)
-                            }
-                            .padding(.vertical, 16)
-                            .accessibilityElement(children: .combine)
-                            .accessibilityLabel("Start Searching")
-                            .accessibilityHint("Enter a recipe name or ingredient to find recipes")
-                        } else if !searchText.isEmpty && filteredRecipes.isEmpty {
-                            // Empty state when no recipes are found after searching
-                            VStack(spacing: 16) {
-                                Image(systemName: "exclamationmark.triangle.fill")
-                                    .font(.system(size: 48))
-                                    .foregroundColor(.gray.opacity(0.8))
-                                Text("No recipes found")
-                                    .font(.title2)
-                                    .fontWeight(.bold)
-                                    .foregroundColor(.primary)
-                                Text("Try adjusting your search term or search in another field.")
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                                    .multilineTextAlignment(.center)
-                                    .padding(.horizontal, horizontalSizeClass == .regular ? 48 : 32)
-                            }
-                            .padding(.vertical, 32)
-                            .accessibilityElement(children: .combine)
-                            .accessibilityLabel("No recipes found")
-                            .accessibilityHint("No recipes match your search term. Try adjusting it or search in another field.")
-                        } else {
-                            // Search results
-                            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
-                                ForEach(filteredRecipes.keys.sorted(), id: \.self) { letter in
-                                    Section {
-                                        ForEach(filteredRecipes[letter] ?? [], id: \.name) { recipe in
-                                            NavigationLink {
-                                                RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
-                                                    .onAppear {
-                                                        saveRecentSearch(recipe)
-                                                        HapticFeedback.impact()
-                                                    }
-                                            } label: {
-                                                RecipeCell(recipe: recipe, isCraftifyPick: false)
-                                            }
-                                            .buttonStyle(.plain)
-                                            .contentShape(Rectangle())
-                                        }
-                                    } header: {
-                                        Text(letter)
-                                            .font(.headline)
-                                            .fontWeight(.bold)
-                                            .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
-                                            .padding(.vertical, 8)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .background(Color(.systemGroupedBackground))
-                                    }
-                                }
-                            }
-                        }
+                        resultsContent
                     }
                 }
-                .safeAreaInset(edge: .bottom, content: { Color.clear.frame(height: 0) })
-            }
-            .scrollContentBackground(.hidden)
-            .background(Color(.systemGroupedBackground).ignoresSafeArea())
-            .id(accentColorPreference)
-            .overlay {
-                if dataManager.isLoading && dataManager.recipes.isEmpty {
-                    VStack(spacing: 12) {
-                        ProgressView()
-                            .progressViewStyle(.circular)
-                            .tint(Color.userAccentColor)
-                        Text("Loading Recipes…")
-                            .font(.headline)
-                            .foregroundColor(.secondary)
-                    }
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(Color(.systemGroupedBackground))
-                    .accessibilityElement(children: .combine)
-                    .accessibilityLabel("Loading Recipes")
-                    .accessibilityHint("Please wait while the recipes are being loaded")
-                }
+                .craftifyContentWidth()
+                .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+                .padding(.top, 12)
+                .padding(.bottom, 34)
             }
             .navigationTitle("Search")
             .navigationBarTitleDisplayMode(.large)
-            .toolbar(.visible, for: .navigationBar)
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+            .searchable(
+                text: $searchText,
+                isPresented: $isSearchActive,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "Search recipes"
+            )
             .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Menu {
                         ForEach(SearchFilter.allCases) { filter in
                             Button {
@@ -253,40 +96,28 @@ struct RecipeSearchView: View {
                                 updateFilteredRecipes()
                                 HapticFeedback.selection()
                             } label: {
-                                Label(filter.rawValue, systemImage: searchFilter == filter ? "checkmark" : "magnifyingglass")
+                                Label(filter.rawValue, systemImage: searchFilter == filter ? "checkmark" : filter.symbol)
                             }
                         }
                     } label: {
-                        Image(systemName: "line.3.horizontal.decrease.circle")
+                        Label("Search Field", systemImage: "line.3.horizontal.decrease.circle")
                     }
-                    .simultaneousGesture(TapGesture().onEnded { HapticFeedback.impact() })
                     .accessibilityLabel("Search in \(searchFilter.rawValue)")
-                    .accessibilityHint("Choose whether to search recipe names, ingredients, or both")
+                    .accessibilityHint("Changes which recipe fields Craftify searches")
                 }
             }
-            .searchable(
-                text: $searchText,
-                isPresented: $isSearchActive,
-                placement: .navigationBarDrawer(displayMode: .always),
-                prompt: "Search recipes"
-            )
-            .onChange(of: isSearchActive) { _, newValue in
-                if !newValue {
-                    searchText = ""
+            .overlay {
+                if dataManager.isLoading && dataManager.recipes.isEmpty {
+                    loadingState
                 }
             }
-            .onChange(of: dataManager.isLoading) { _, newValue in
-                if !newValue && dataManager.isManualSyncing {
-                    updateFilteredRecipes()
-                }
+            .craftifyPage()
+            .onChange(of: isSearchActive) { _, active in
+                if !active { searchText = "" }
             }
-            .task(id: searchText) {
-                await MainActor.run {
-                    updateFilteredRecipes()
-                }
-            }
+            .onChange(of: searchText) { _, _ in updateFilteredRecipes() }
+            .onChange(of: dataManager.recipes) { _, _ in updateFilteredRecipes() }
             .onAppear {
-                // Sync chests, recent searches, and fetch recipes
                 dataManager.syncChests()
                 dataManager.syncRecentSearches()
                 dataManager.fetchRecipes(isManual: false)
@@ -294,80 +125,192 @@ struct RecipeSearchView: View {
             }
             .navigationDestination(for: Recipe.self) { recipe in
                 RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
+                    .onAppear {
+                        dataManager.saveRecentSearch(recipe)
+                        HapticFeedback.impact(.light)
+                    }
             }
-            .dynamicTypeSize(.xSmall ... .accessibility5)
         }
+    }
+
+    private var inactiveContent: some View {
+        Group {
+            CraftifyHero(
+                eyebrow: "Find Anything",
+                title: "Search Your Recipe Book",
+                detail: "Search by recipe name, ingredient, or both. Your recent finds follow you through iCloud.",
+                symbol: "magnifyingglass"
+            )
+
+            if recentSearchRecipes.isEmpty {
+                searchState(
+                    symbol: "sparkle.magnifyingglass",
+                    title: "What Are You Crafting?",
+                    detail: "Tap the search field and start with a recipe name or ingredient."
+                )
+            } else {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(alignment: .firstTextBaseline) {
+                        CraftifySectionHeader(
+                            title: "Recent Searches",
+                            detail: "Quickly return to recipes you opened before."
+                        )
+                        Spacer(minLength: 12)
+                        Button("Clear All") {
+                            dataManager.clearRecentSearches()
+                            HapticFeedback.impact(.medium)
+                        }
+                        .font(.subheadline.weight(.semibold))
+                        .accessibilityHint("Removes all recent recipe searches")
+                    }
+
+                    RecentSearchesList(
+                        recipes: recentSearchRecipes,
+                        navigationPath: $navigationPath
+                    )
+                }
+            }
+        }
+    }
+
+    private var resultsContent: some View {
+        Group {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Search Results")
+                        .font(.title2.bold())
+                    Text("Searching \(searchFilter.rawValue.lowercased())")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                CraftifyStatusPill(
+                    title: "\(resultCount) found",
+                    symbol: "magnifyingglass"
+                )
+            }
+
+            ForEach(filteredRecipes.keys.sorted(), id: \.self) { letter in
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(letter)
+                        .font(.title2.bold())
+                        .foregroundStyle(Color.userAccentColor)
+                        .accessibilityAddTraits(.isHeader)
+
+                    LazyVGrid(columns: resultColumns, alignment: .leading, spacing: 12) {
+                        ForEach(filteredRecipes[letter] ?? []) { recipe in
+                            NavigationLink(value: recipe) {
+                                RecipeCell(recipe: recipe, isCraftifyPick: false)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private var resultCount: Int {
+        filteredRecipes.values.reduce(0) { $0 + $1.count }
+    }
+
+    private func searchState(symbol: String, title: String, detail: String) -> some View {
+        CraftifyEmptyState(symbol: symbol, title: title, detail: detail)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 8)
+    }
+
+    private var loadingState: some View {
+        VStack(spacing: 14) {
+            ProgressView().controlSize(.large).tint(Color.userAccentColor)
+            Text("Loading Recipes…").font(.headline)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background { AppBackground().ignoresSafeArea() }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Loading recipes")
+    }
+
+    private func updateFilteredRecipes() {
+        let matches = searchText.isEmpty ? dataManager.recipes : dataManager.recipes.filter { recipe in
+            switch searchFilter {
+            case .all:
+                recipe.name.localizedCaseInsensitiveContains(searchText)
+                    || recipe.ingredients.contains { $0.localizedCaseInsensitiveContains(searchText) }
+            case .names:
+                recipe.name.localizedCaseInsensitiveContains(searchText)
+            case .ingredients:
+                recipe.ingredients.contains { $0.localizedCaseInsensitiveContains(searchText) }
+            }
+        }
+
+        filteredRecipes = Dictionary(grouping: matches) {
+            String($0.name.prefix(1)).uppercased()
+        }
+        .mapValues { $0.sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending } }
     }
 }
 
-// A compact view for displaying recent search items
 struct RecentSearchItem: View {
     let recipe: Recipe
-    let accentColorPreference: String
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    
+
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 13) {
             CraftImage(key: recipe.image)
                 .scaledToFit()
-                .frame(width: horizontalSizeClass == .regular ? 40 : 32, height: horizontalSizeClass == .regular ? 40 : 32)
-                .cornerRadius(6)
-                .accessibilityLabel("Image of \(recipe.name)")
-            
-            Text(recipe.name)
-                .font(.subheadline)
-                .fontWeight(.medium)
-                .foregroundColor(.primary)
-                .lineLimit(1)
-            
-            Spacer()
-            
+                .frame(width: 48, height: 48)
+                .padding(5)
+                .background(Color.userAccentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(recipe.name)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
+                Text(recipe.category)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 3)
             Image(systemName: "chevron.right")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(Color.userAccentColor)
+                .font(.caption.bold())
+                .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-        .contentShape(Rectangle())
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(recipe.name) recent search")
-        .accessibilityHint("Navigates to the detailed view of \(recipe.name)")
-        .dynamicTypeSize(.xSmall ... .accessibility5)
+        .padding(13)
+        .frame(maxWidth: .infinity, minHeight: 76, alignment: .leading)
+        .craftifyCard(cornerRadius: 17)
+        .contentShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(recipe.name), recent search")
+        .accessibilityHint("Opens the crafting recipe")
     }
 }
 
-// Extracted view for the recent searches list
 struct RecentSearchesList: View {
     let recipes: [Recipe]
     @Binding var navigationPath: NavigationPath
-    let accentColorPreference: String
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    
+
+    private var columns: [GridItem] {
+        CraftifyLayout.adaptiveColumns(
+            minimum: dynamicTypeSize.isAccessibilitySize ? 300 : 280,
+            maximum: 420,
+            spacing: 12,
+            dynamicTypeSize: dynamicTypeSize
+        )
+    }
+
     var body: some View {
-        LazyVStack(spacing: 0) {
-            ForEach(Array(recipes.enumerated()), id: \.element.name) { index, recipe in
-                NavigationLink {
-                    RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
-                } label: {
-                    RecentSearchItem(recipe: recipe, accentColorPreference: accentColorPreference)
+        LazyVGrid(columns: columns, spacing: 12) {
+            ForEach(recipes) { recipe in
+                NavigationLink(value: recipe) {
+                    RecentSearchItem(recipe: recipe)
                 }
                 .buttonStyle(.plain)
-                
-                if index < recipes.count - 1 {
-                    Divider()
-                        .padding(.leading, horizontalSizeClass == .regular ? 56 : 48)
-                }
             }
         }
-        .background(Color(.secondarySystemGroupedBackground))
-        .overlay {
-            RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 10))
-        .padding(.horizontal, horizontalSizeClass == .regular ? 24 : 16)
-        .dynamicTypeSize(.xSmall ... .accessibility5)
     }
 }

--- a/Craftify/ReleaseNotesView.swift
+++ b/Craftify/ReleaseNotesView.swift
@@ -8,78 +8,78 @@
 import SwiftUI
 
 struct ReleaseNotesView: View {
-    @EnvironmentObject var dataManager: DataManager
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @AppStorage("accentColorPreference") private var accentColorPreference: String = "default"
-    @ScaledMetric(relativeTo: .body) private var paddingVertical: CGFloat = 8
-    @ScaledMetric(relativeTo: .body) private var paddingHorizontal: CGFloat = 12
-    @ScaledMetric(relativeTo: .body) private var sectionSpacing: CGFloat = 8
-    @ScaledMetric(relativeTo: .body) private var listRowPaddingVertical: CGFloat = 8
-    
+
     private var appVersion: String {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
         let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "33"
-        return "Version \(version) - Build \(build)"
+        return "Version \(version) • Build \(build)"
     }
-    
+
     var body: some View {
-        List {
-            Section {
-                VStack(alignment: .leading, spacing: horizontalSizeClass == .regular ? sectionSpacing * 1.5 : sectionSpacing) {
-                    Text("Craftify for Minecraft")
-                        .font(horizontalSizeClass == .regular ? .title : .largeTitle)
-                        .fontWeight(.bold)
-                        .minimumScaleFactor(0.6)
-                    
-                    Text(appVersion)
-                        .font(horizontalSizeClass == .regular ? .title3 : .headline)
-                        .foregroundColor(Color.userAccentColor)
-                        .minimumScaleFactor(0.6)
-                    
-                    Text("Stay updated with the latest improvements, fixes, and new features added to Craftify.")
-                        .font(horizontalSizeClass == .regular ? .body : .subheadline)
-                        .foregroundColor(.primary)
-                        .padding(.top, paddingVertical * 0.5)
-                        .minimumScaleFactor(0.6)
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 16) {
+                CraftifyHero(
+                    eyebrow: appVersion,
+                    title: "What’s New in Craftify",
+                    detail: "Follow the features, refinements, and fixes that shaped your crafting companion.",
+                    symbol: "sparkles"
+                )
+
+                ForEach(Array(releaseNotes.enumerated()), id: \.element.version) { index, note in
+                    ReleaseNoteCard(note: note, isCurrent: index == 0)
                 }
-                .padding(.bottom, paddingVertical)
-                .padding(.horizontal, horizontalSizeClass == .regular ? min(paddingHorizontal * 1.5, 24) : paddingHorizontal)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Craftify for Minecraft")
-                .accessibilityValue("\(appVersion). Stay updated with the latest improvements, fixes, and new features.")
-                .accessibilityHint("Release notes overview")
             }
-            .listRowBackground(AppBackground())
-            
-            ForEach(releaseNotes, id: \.version) { note in
-                Section(header: Text(note.version)
-                            .font(.headline)
-                            .foregroundColor(.secondary)) {
-                    ForEach(note.changes, id: \.self) { change in
-                        Label {
-                            Text(change)
-                                .foregroundStyle(.primary)
-                        } icon: {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(Color.userAccentColor)
-                        }
+            .craftifyContentWidth(CraftifyLayout.readingMaxWidth)
+            .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+            .padding(.top, 12)
+            .padding(.bottom, 34)
+        }
+        .navigationTitle("Release Notes")
+        .navigationBarTitleDisplayMode(.large)
+        .craftifyPage()
+    }
+}
+
+private struct ReleaseNoteCard: View {
+    let note: ReleaseNote
+    let isCurrent: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 15) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(note.version)
+                    .font(.title3.bold())
+                    .foregroundStyle(.primary)
+                Spacer(minLength: 4)
+                if isCurrent {
+                    CraftifyStatusPill(title: "Current", symbol: "checkmark.seal.fill")
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 11) {
+                ForEach(note.changes, id: \.self) { change in
+                    HStack(alignment: .top, spacing: 11) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(Color.userAccentColor)
+                            .accessibilityHidden(true)
+                        Text(change)
                             .font(.body)
-                            .padding(.vertical, horizontalSizeClass == .regular ? listRowPaddingVertical * 1.5 : listRowPaddingVertical)
-                            .accessibilityLabel(change)
+                            .foregroundStyle(.primary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
+                    .accessibilityElement(children: .combine)
                 }
             }
         }
-        .id(accentColorPreference)
-        .listStyle(InsetGroupedListStyle())
-        .scrollContentBackground(.hidden)
-        .background(Color(.systemGroupedBackground))
-        .navigationTitle("Release Notes")
-        .navigationBarTitleDisplayMode(.large)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-        .dynamicTypeSize(.xSmall ... .accessibility5)
+        .padding(18)
+        .craftifyCard(cornerRadius: 22)
+        .overlay(alignment: .leading) {
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(isCurrent ? Color.userAccentColor : Color.userAccentColor.opacity(0.28))
+                .frame(width: 4)
+                .padding(.vertical, 18)
+        }
     }
 }
 

--- a/Craftify/ReportRecipeView.swift
+++ b/Craftify/ReportRecipeView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ReportRecipeView: View {
     @EnvironmentObject private var dataManager: DataManager
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
 
     @State private var viewMode: ViewMode = .submitReport
@@ -77,7 +78,7 @@ struct ReportRecipeView: View {
     private var isSubmissionOnCooldown: Bool { remainingSubmissionCooldown > 0 }
     var body: some View {
         ZStack {
-            Color(uiColor: .systemGroupedBackground).ignoresSafeArea()
+            AppBackground().ignoresSafeArea()
 
             ScrollView {
                 LazyVStack(spacing: 20) {
@@ -112,7 +113,8 @@ struct ReportRecipeView: View {
                     }
                 }
                 .frame(maxWidth: .infinity)
-                .padding(.horizontal, 16)
+                .frame(maxWidth: CraftifyLayout.formMaxWidth)
+                .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
                 .padding(.top, 12)
                 .padding(.bottom, 32)
             }
@@ -135,7 +137,7 @@ struct ReportRecipeView: View {
         }
         .navigationTitle("Report a Recipe")
         .navigationBarTitleDisplayMode(.large)
-        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
+        .craftifyPage()
         .alert("Delete report?", isPresented: $showDeleteConfirmation) {
             Button("Delete", role: .destructive) {
                 if let reportToDelete { deleteReport(reportToDelete) }
@@ -166,30 +168,12 @@ struct ReportRecipeView: View {
     }
 
     private var introHeader: some View {
-        HStack(spacing: 14) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 16, style: .continuous)
-                    .fill(Color.userAccentColor.gradient)
-                Image(systemName: "hammer.fill")
-                    .font(.system(size: 25, weight: .semibold))
-                    .foregroundStyle(.white)
-            }
-            .frame(width: 58, height: 58)
-            .shadow(color: Color.userAccentColor.opacity(0.22), radius: 8, y: 4)
-
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Help improve Craftify")
-                    .font(.title3.bold())
-                Text("Send feedback and follow every update in one place.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-            Spacer(minLength: 0)
-        }
-        .padding(16)
-        .background(Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
-        .accessibilityElement(children: .combine)
+        CraftifyHero(
+            eyebrow: "Community Workshop",
+            title: "Help Improve Craftify",
+            detail: "Send recipe feedback and follow every update from one clear workspace.",
+            symbol: "exclamationmark.bubble.fill"
+        )
     }
 
     private var modeSelector: some View {
@@ -210,7 +194,7 @@ struct ReportRecipeView: View {
             }
         }
         .padding(5)
-        .background(Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .craftifyCard(cornerRadius: 16)
     }
 
     private func resetForm() {
@@ -400,9 +384,15 @@ private struct SubmitReportSection: View {
     private var reportTypeCards: some View {
         VStack(alignment: .leading, spacing: 10) {
             Text("WHAT HAPPENED?").font(.caption.bold()).foregroundStyle(.secondary)
-            HStack(spacing: 10) {
-                typeButton(.missingRecipe)
-                typeButton(.recipeError)
+            ViewThatFits(in: .horizontal) {
+                HStack(spacing: 10) {
+                    typeButton(.missingRecipe)
+                    typeButton(.recipeError)
+                }
+                VStack(spacing: 10) {
+                    typeButton(.missingRecipe)
+                    typeButton(.recipeError)
+                }
             }
         }
     }
@@ -496,7 +486,7 @@ private struct SubmitReportSection: View {
             }
         }
         .padding(18)
-        .background(Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .craftifyCard(cornerRadius: 20)
     }
 }
 
@@ -592,7 +582,7 @@ private struct MyReportsSection: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(18)
-        .background(Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .craftifyCard(cornerRadius: 20)
         .accessibilityElement(children: .combine)
     }
 }
@@ -614,7 +604,7 @@ private struct EmptyReportState: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 28).padding(.vertical, 34)
-        .background(Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .craftifyCard(cornerRadius: 20)
         .accessibilityElement(children: .combine)
     }
 }
@@ -684,7 +674,7 @@ private struct ReportCard: View {
             }
         }
         .padding(16)
-        .background(Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .craftifyCard(cornerRadius: 20)
         .overlay(alignment: .leading) {
             RoundedRectangle(cornerRadius: 3).fill(statusColor).frame(width: 4).padding(.vertical, 18)
         }
@@ -728,7 +718,7 @@ private struct SubmissionPopup: View {
             }
             .padding(24)
             .frame(maxWidth: 340)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .craftifyFloatingSurface(cornerRadius: 24)
             .shadow(color: .black.opacity(0.18), radius: 24, y: 10)
             .padding(24)
             .accessibilityAddTraits(.isModal)
@@ -761,7 +751,7 @@ private struct DeleteConfirmationPopup: View {
                     .background(Color.userAccentColor, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .padding(24).frame(maxWidth: 320)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .craftifyFloatingSurface(cornerRadius: 24)
             .padding(24).accessibilityAddTraits(.isModal)
         }
     }

--- a/Craftify/SupportView.swift
+++ b/Craftify/SupportView.swift
@@ -69,12 +69,10 @@ struct SupportView: View {
                         symbol: "lock.shield.fill"
                     )
 
-                    Link(
-                        "View Privacy Policy Online",
-                        systemImage: "arrow.up.right.square",
-                        destination: URL(string: "https://www.davevancauwenberghe.be/projects/craftify-for-minecraft/privacy-policy/")!
-                    )
-                    .font(.headline)
+                    Link(destination: URL(string: "https://www.davevancauwenberghe.be/projects/craftify-for-minecraft/privacy-policy/")!) {
+                        Label("View Privacy Policy Online", systemImage: "arrow.up.right.square")
+                            .font(.headline)
+                    }
 
                     DisclosureGroup(isExpanded: $isPrivacyExpanded) {
                         PrivacyPolicyContent(horizontalSizeClass: horizontalSizeClass)
@@ -138,11 +136,22 @@ struct SupportView: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            Button(actionTitle, systemImage: symbol, role: isDestructive ? .destructive : nil, action: action)
+            if isDestructive {
+                Button(role: .destructive, action: action) {
+                    Label(actionTitle, systemImage: symbol)
+                }
                 .buttonStyle(.bordered)
                 .controlSize(.large)
                 .tint(.red)
                 .accessibilityHint(detail)
+            } else {
+                Button(action: action) {
+                    Label(actionTitle, systemImage: symbol)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .accessibilityHint(detail)
+            }
         }
         .padding(18)
         .craftifyCard(cornerRadius: 22)

--- a/Craftify/SupportView.swift
+++ b/Craftify/SupportView.swift
@@ -6,168 +6,165 @@
 //
 
 import SwiftUI
+import UIKit
 
 struct SupportView: View {
-    @EnvironmentObject var dataManager: DataManager
+    @EnvironmentObject private var dataManager: DataManager
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
-    @State private var showClearDataAlert: Bool = false
-    @State private var showErrorAlert: Bool = false
+    @State private var showClearDataAlert = false
+    @State private var showErrorAlert = false
     @State private var errorMessage: String?
+    @State private var isPrivacyExpanded = false
 
     var body: some View {
-            List {
-                Section(header: Text("Support").font(.headline).minimumScaleFactor(0.6)) {
-                    Button(action: {
-                        HapticFeedback.selection()
-                        let supportEmail = "hello@davevancauwenberghe.be"
-                        if let url = URL(string: "mailto:\(supportEmail)") {
-                            UIApplication.shared.open(url)
-                        }
-                    }) {
-                        buttonStyle(title: "Contact Support", systemImage: "envelope.fill")
-                    }
-                    .buttonStyle(.plain)
-                    .listRowInsets(EdgeInsets(
-                        top: horizontalSizeClass == .regular ? 12 : 8,
-                        leading: horizontalSizeClass == .regular ? 16 : 12,
-                        bottom: horizontalSizeClass == .regular ? 12 : 8,
-                        trailing: horizontalSizeClass == .regular ? 16 : 12
-                    ))
-                    .accessibilityLabel("Contact Support")
-                    .accessibilityHint("Opens the mail app to contact support")
-                }
-
-                Section(header: Text("Data Management").font(.headline).minimumScaleFactor(0.6)) {
-                    Button(action: {
-                        showClearDataAlert = true
-                    }) {
-                        buttonStyle(title: "Clear All Data", systemImage: "trash.fill", foregroundColor: .red)
-                    }
-                    .buttonStyle(.plain)
-                    .listRowInsets(EdgeInsets(
-                        top: horizontalSizeClass == .regular ? 12 : 8,
-                        leading: horizontalSizeClass == .regular ? 16 : 12,
-                        bottom: horizontalSizeClass == .regular ? 12 : 8,
-                        trailing: horizontalSizeClass == .regular ? 16 : 12
-                    ))
-                    .accessibilityLabel("Clear All Data")
-                    .accessibilityHint("Clears local recipe data, downloaded images, chests, recent searches, and recipe reports")
-
-                    Text("This will permanently delete your chests, recent searches, CloudKit recipe reports, local recipe data, and downloaded recipe images.")
-                        .font(horizontalSizeClass == .regular ? .body : .subheadline)
-                        .foregroundColor(.secondary)
-                        .multilineTextAlignment(.leading)
-                        .minimumScaleFactor(0.6)
-                        .padding(.horizontal, horizontalSizeClass == .regular ? 12 : 8)
-                        .padding(.vertical, horizontalSizeClass == .regular ? 8 : 4)
-                        .accessibilityLabel("Clear All Data Note")
-                        .accessibilityHint("This will permanently delete your chests, recent searches, recipe reports, local recipe data, and downloaded recipe images.")
-
-                    Button(action: {
-                        dataManager.clearCache { success in
-                            if success {
-                                HapticFeedback.notification(.success)
-                            } else {
-                                HapticFeedback.notification(.error)
-                                errorMessage = dataManager.errorMessage ?? "Failed to clear cache. Please try again."
-                                showErrorAlert = true
-                            }
-                        }
-                    }) {
-                        buttonStyle(title: "Clear Cache", systemImage: "trash.fill", foregroundColor: .red)
-                    }
-                    .buttonStyle(.plain)
-                    .listRowInsets(EdgeInsets(
-                        top: horizontalSizeClass == .regular ? 12 : 8,
-                        leading: horizontalSizeClass == .regular ? 16 : 12,
-                        bottom: horizontalSizeClass == .regular ? 12 : 8,
-                        trailing: horizontalSizeClass == .regular ? 16 : 12
-                    ))
-                    .accessibilityLabel("Clear Cache")
-                    .accessibilityHint("Clears local Minecraft recipes and downloaded images, keeping iCloud data like chests")
-
-                    Text("This will permanently delete local recipe data and downloaded recipe images, keeping iCloud data like chests and recent searches.")
-                        .font(horizontalSizeClass == .regular ? .body : .subheadline)
-                        .foregroundColor(.secondary)
-                        .multilineTextAlignment(.leading)
-                        .minimumScaleFactor(0.6)
-                        .padding(.horizontal, horizontalSizeClass == .regular ? 12 : 8)
-                        .padding(.vertical, horizontalSizeClass == .regular ? 8 : 4)
-                        .accessibilityLabel("Clear Cache Note")
-                        .accessibilityHint("This will permanently delete local recipe data and downloaded recipe images, keeping iCloud data like chests and recent searches.")
-                }
-
-                Section(header: Text("Privacy").font(.headline).minimumScaleFactor(0.6)) {
-                    Button(action: {
-                        HapticFeedback.selection()
-                        if let url = URL(string: "https://www.davevancauwenberghe.be/projects/craftify-for-minecraft/privacy-policy/") {
-                            UIApplication.shared.open(url)
-                        }
-                    }) {
-                        buttonStyle(title: "View Privacy Policy Online", systemImage: "safari.fill")
-                    }
-                    .buttonStyle(.plain)
-                    .listRowInsets(EdgeInsets(
-                        top: horizontalSizeClass == .regular ? 12 : 8,
-                        leading: horizontalSizeClass == .regular ? 16 : 12,
-                        bottom: horizontalSizeClass == .regular ? 12 : 8,
-                        trailing: horizontalSizeClass == .regular ? 16 : 12
-                    ))
-                    .accessibilityLabel("View Privacy Policy Online")
-                    .accessibilityHint("Opens the privacy policy in your web browser")
-
-                    PrivacyPolicyContent(horizontalSizeClass: horizontalSizeClass)
-                }
-            }
-            .listStyle(InsetGroupedListStyle())
-            .scrollContentBackground(.hidden)
-            .navigationTitle("Support & Privacy")
-            .navigationBarTitleDisplayMode(.large)
-            .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
-            .background(Color(UIColor.systemGroupedBackground))
-            .alert(isPresented: $showErrorAlert) {
-                Alert(
-                    title: Text("Error"),
-                    message: Text(errorMessage ?? "An error occurred."),
-                    dismissButton: .cancel(Text("OK")) {
-                        errorMessage = nil
-                    }
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 24) {
+                CraftifyHero(
+                    eyebrow: "Help & Control",
+                    title: "Support & Privacy",
+                    detail: "Contact support, manage Craftify’s downloaded and synced data, and review exactly how the app protects your privacy.",
+                    symbol: "hand.raised.fill"
                 )
-            }
-            .alert(isPresented: $showClearDataAlert) {
-                Alert(
-                    title: Text("Clear All Data"),
-                    message: Text("Are you sure? This will remove your chests, recent searches, CloudKit recipe reports, local recipe data, and downloaded recipe images. This action cannot be undone."),
-                    primaryButton: .destructive(Text("Clear All Data")) {
-                        dataManager.clearAllData { success in
-                            if success {
-                                HapticFeedback.notification(.success)
-                            } else {
-                                HapticFeedback.notification(.error)
-                                errorMessage = dataManager.errorMessage ?? "Failed to clear all data. Please try again."
-                                showErrorAlert = true
-                            }
-                        }
-                    },
-                    secondaryButton: .cancel()
+
+                VStack(alignment: .leading, spacing: 14) {
+                    CraftifySectionHeader(
+                        title: "Need a Hand?",
+                        detail: "Send a message directly to Craftify support.",
+                        symbol: "envelope.fill"
+                    )
+                    Button("Contact Support", systemImage: "envelope.fill", action: contactSupport)
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.large)
+                        .accessibilityHint("Opens the Mail app")
+                }
+                .padding(18)
+                .craftifyCard(cornerRadius: 22)
+
+                CraftifySectionHeader(
+                    title: "Data Management",
+                    detail: "Choose whether to remove only downloaded content or every piece of Craftify data."
                 )
+
+                dataActionCard(
+                    title: "Clear Cache",
+                    detail: "Removes local recipes and downloaded images. Your iCloud chests, recent searches, and reports stay intact.",
+                    symbol: "externaldrive.badge.xmark",
+                    actionTitle: "Clear Cache",
+                    action: clearCache
+                )
+
+                dataActionCard(
+                    title: "Clear All Data",
+                    detail: "Permanently removes chests, recent searches, CloudKit reports, local recipes, and downloaded images.",
+                    symbol: "trash.fill",
+                    actionTitle: "Clear All Data",
+                    isDestructive: true,
+                    action: { showClearDataAlert = true }
+                )
+
+                VStack(alignment: .leading, spacing: 14) {
+                    CraftifySectionHeader(
+                        title: "Privacy Policy",
+                        detail: "Craftify asks for no identity or account details and uses no third-party dependencies.",
+                        symbol: "lock.shield.fill"
+                    )
+
+                    Link(
+                        "View Privacy Policy Online",
+                        systemImage: "arrow.up.right.square",
+                        destination: URL(string: "https://www.davevancauwenberghe.be/projects/craftify-for-minecraft/privacy-policy/")!
+                    )
+                    .font(.headline)
+
+                    DisclosureGroup(isExpanded: $isPrivacyExpanded) {
+                        PrivacyPolicyContent(horizontalSizeClass: horizontalSizeClass)
+                            .padding(.top, 14)
+                    } label: {
+                        Label("Read Privacy Policy in Craftify", systemImage: "doc.text.fill")
+                            .font(.headline)
+                    }
+                    .onChange(of: isPrivacyExpanded) { _, _ in HapticFeedback.selection() }
+                }
+                .padding(18)
+                .craftifyCard(cornerRadius: 22)
             }
-            .dynamicTypeSize(.xSmall ... .accessibility5)
+            .craftifyContentWidth(CraftifyLayout.readingMaxWidth)
+            .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
+            .padding(.top, 12)
+            .padding(.bottom, 34)
+        }
+        .navigationTitle("Support & Privacy")
+        .navigationBarTitleDisplayMode(.large)
+        .craftifyPage()
+        .alert("Error", isPresented: $showErrorAlert) {
+            Button("OK", role: .cancel) { errorMessage = nil }
+        } message: {
+            Text(errorMessage ?? "An error occurred.")
+        }
+        .alert("Clear All Data", isPresented: $showClearDataAlert) {
+            Button("Clear All Data", role: .destructive) {
+                dataManager.clearAllData { success in
+                    if success {
+                        HapticFeedback.notification(.success)
+                    } else {
+                        HapticFeedback.notification(.error)
+                        errorMessage = dataManager.errorMessage ?? "Failed to clear all data. Please try again."
+                        showErrorAlert = true
+                    }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes your chests, recent searches, CloudKit recipe reports, local recipes, and downloaded images. This action cannot be undone.")
+        }
     }
 
-    private func buttonStyle(title: String, systemImage: String, foregroundColor: Color = Color.userAccentColor) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: systemImage)
-                .font(.title2)
-                .foregroundColor(foregroundColor)
-            Text(title)
-                .font(.headline)
-                .foregroundColor(.primary)
-                .minimumScaleFactor(0.6)
-            Spacer()
+    private func dataActionCard(
+        title: String,
+        detail: String,
+        symbol: String,
+        actionTitle: String,
+        isDestructive: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 15) {
+            HStack(alignment: .top, spacing: 14) {
+                CraftifyIconTile(symbol: symbol, size: 52, destructive: isDestructive)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title).font(.title3.bold())
+                    Text(detail)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Button(actionTitle, systemImage: symbol, role: isDestructive ? .destructive : nil, action: action)
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+                .tint(.red)
+                .accessibilityHint(detail)
         }
-        .padding(.vertical, horizontalSizeClass == .regular ? 12 : 8)
+        .padding(18)
+        .craftifyCard(cornerRadius: 22)
+    }
+
+    private func contactSupport() {
+        HapticFeedback.selection()
+        if let url = URL(string: "mailto:hello@davevancauwenberghe.be") {
+            UIApplication.shared.open(url)
+        }
+    }
+
+    private func clearCache() {
+        dataManager.clearCache { success in
+            if success {
+                HapticFeedback.notification(.success)
+            } else {
+                HapticFeedback.notification(.error)
+                errorMessage = dataManager.errorMessage ?? "Failed to clear cache. Please try again."
+                showErrorAlert = true
+            }
+        }
     }
 }
 
@@ -188,7 +185,7 @@ struct PrivacyPolicyContent: View {
                 .foregroundColor(.secondary)
                 .minimumScaleFactor(0.6)
 
-            ScrollView {
+            Group {
                 VStack(alignment: .leading, spacing: 16) {
                     Text("Craftify for Minecraft (\"Craftify\") is developed by Dave Van Cauwenberghe, an individual developer. This Privacy Policy explains how Craftify handles your data. Craftify does not ask you for identity or account details. You choose chest names, so avoid including personal information in them.")
                         .font(.body)
@@ -374,10 +371,6 @@ struct PrivacyPolicyContent: View {
                 }
                 .padding(.vertical, 8)
             }
-            .frame(maxHeight: 300)
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("Privacy Policy for Craftify")
-            .accessibilityValue("Last updated 30 July 2026. Craftify does not ask for identity or account details. Data includes user-entered chest names, sizes, ordering and recipe IDs, Recent Searches, and Recipe Reports stored in iCloud and CloudKit for syncing. Network connectivity is monitored locally to manage syncing, not shared. Data is used for app features, with no third-party sharing. Anonymized CloudKit metadata is used for performance. You can clear all data. Craftify is safe for kids under 13, complying with COPPA and GDPR.")
         }
         .padding(.vertical, 8)
         .dynamicTypeSize(.xSmall ... .accessibility5)

--- a/Craftify/SyncOverlayView.swift
+++ b/Craftify/SyncOverlayView.swift
@@ -216,6 +216,7 @@ private struct CraftifyOverlayCard<Footer: View>: View {
     let footer: Footer
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @State private var isAnimating = false
 
     init(
@@ -237,44 +238,52 @@ private struct CraftifyOverlayCard<Footer: View>: View {
     }
 
     private var cardWidth: CGFloat {
-        horizontalSizeClass == .regular ? 420 : 330
+        horizontalSizeClass == .regular ? 440 : 350
     }
 
     var body: some View {
-        ZStack {
-            Color.black.opacity(0.32)
-                .ignoresSafeArea()
+        GeometryReader { geometry in
+            ZStack {
+                Color.black.opacity(reduceTransparency ? 0.52 : 0.34)
+                    .ignoresSafeArea()
 
-            VStack(spacing: 20) {
-                if showsIllustration {
-                    illustration
+                ScrollView {
+                    VStack {
+                        Spacer(minLength: 20)
+
+                        VStack(spacing: 20) {
+                            if showsIllustration {
+                                illustration
+                            }
+
+                            VStack(spacing: 7) {
+                                Text(title)
+                                    .font(.title3.weight(.semibold))
+                                    .foregroundStyle(.primary)
+                                    .multilineTextAlignment(.center)
+
+                                Text(detail)
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                                    .multilineTextAlignment(.center)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+
+                            footer
+                        }
+                        .padding(.horizontal, 28)
+                        .padding(.vertical, 30)
+                        .frame(maxWidth: cardWidth)
+                        .craftifyFloatingSurface(cornerRadius: 28)
+                        .shadow(color: .black.opacity(0.18), radius: 24, y: 12)
+                        .padding(.horizontal, 20)
+
+                        Spacer(minLength: 20)
+                    }
+                    .frame(minHeight: geometry.size.height)
                 }
-
-                VStack(spacing: 7) {
-                    Text(title)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(.primary)
-                        .multilineTextAlignment(.center)
-
-                    Text(detail)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                footer
+                .scrollIndicators(.hidden)
             }
-            .padding(.horizontal, 28)
-            .padding(.vertical, 30)
-            .frame(maxWidth: cardWidth)
-            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 26, style: .continuous))
-            .overlay {
-                RoundedRectangle(cornerRadius: 26, style: .continuous)
-                    .stroke(Color.userAccentColor.opacity(0.18), lineWidth: 1)
-            }
-            .shadow(color: .black.opacity(0.18), radius: 24, y: 12)
-            .padding(.horizontal, 24)
         }
         .onAppear { isAnimating = true }
         .onDisappear { isAnimating = false }
@@ -284,31 +293,14 @@ private struct CraftifyOverlayCard<Footer: View>: View {
 
     private var illustration: some View {
         ZStack {
-            Circle()
-                .fill(Color.userAccentColor.opacity(0.10))
-                .frame(width: 108, height: 108)
-                .scaleEffect(isAnimating && !reduceMotion ? 1.08 : 0.94)
-                .opacity(isAnimating && !reduceMotion ? 0.55 : 1)
-                .animation(
-                    reduceMotion ? nil : .easeInOut(duration: 1.6).repeatForever(autoreverses: true),
-                    value: isAnimating
-                )
-
-            RoundedRectangle(cornerRadius: 22, style: .continuous)
-                .fill(Color.userAccentColor.gradient)
-                .frame(width: 76, height: 76)
-                .shadow(color: Color.userAccentColor.opacity(0.24), radius: 14, y: 7)
-
-            Image(systemName: symbol)
-                .font(.system(size: 32, weight: .semibold))
-                .foregroundStyle(.white)
+            CraftifyIconTile(symbol: symbol, size: 82)
 
             Image(systemName: badgeSymbol)
                 .font(.system(size: 19, weight: .semibold))
                 .foregroundStyle(Color.userAccentColor)
                 .padding(7)
                 .background(.regularMaterial, in: Circle())
-                .offset(x: 35, y: 35)
+                .offset(x: 37, y: 37)
                 .scaleEffect(isAnimating && !reduceMotion ? 1 : 0.88)
                 .animation(reduceMotion ? nil : .easeInOut(duration: 0.7), value: isAnimating)
         }

--- a/CraftifyUITests/CraftifyUITests.swift
+++ b/CraftifyUITests/CraftifyUITests.swift
@@ -9,7 +9,7 @@ import XCTest
 
 final class CraftifyUITests: XCTestCase {
     @MainActor
-    func testTextSizePickerInContentView() throws {
+    func testAppearanceControlsAreReachableFromMore() throws {
         continueAfterFailure = false
 
         let app = XCUIApplication()
@@ -22,32 +22,25 @@ final class CraftifyUITests: XCTestCase {
         )
         moreTab.tap()
 
-        let appearanceCell = app.tables.cells.staticTexts["App Appearance"]
+        let appearanceCell = app.staticTexts["App Appearance"]
         XCTAssertTrue(
             appearanceCell.waitForExistence(timeout: 5),
-            "App Appearance cell should exist"
+            "App Appearance destination should exist"
         )
         appearanceCell.tap()
 
-        let textSizeToggle = app.tables.cells.switches["Custom Text Size"]
+        let appearancePicker = app.segmentedControls["Appearance"]
         XCTAssertTrue(
-            textSizeToggle.waitForExistence(timeout: 5),
-            "Custom Text Size toggle should exist"
-        )
-        textSizeToggle.tap()
-
-        let textSizePicker = app.pickers["Text Size Picker"]
-        XCTAssertTrue(
-            textSizePicker.waitForExistence(timeout: 5),
-            "Text Size Picker should be visible"
+            appearancePicker.waitForExistence(timeout: 5),
+            "Appearance picker should exist"
         )
 
-        let pickerWheel = textSizePicker.pickerWheels.element
-        pickerWheel.adjust(toPickerWheelValue: "Extra Large")
-        XCTAssertEqual(
-            pickerWheel.value as? String,
-            "Extra Large",
-            "Picker should select Extra Large"
+        let darkAppearance = appearancePicker.buttons["Dark"]
+        XCTAssertTrue(
+            darkAppearance.exists,
+            "Dark appearance option should exist"
         )
+        darkAppearance.tap()
+        XCTAssertTrue(darkAppearance.isSelected)
     }
 }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Craftify is a sleek iOS app designed for Minecraft players to browse, search, an
 - **CloudKit Syncing**: Keep your favorites in sync across all your devices.
 - **Haptic Feedback**: Enjoy tactile feedback for a more engaging experience.
 
+### Craftify interface
+
+Craftify uses a shared SwiftUI design layer (`CraftifyDesignSystem.swift`) for its crafting-grid backgrounds, adaptive content widths, cards, status badges, empty states, and headers. Screens keep native navigation and controls so iOS and iPadOS 26 receive Liquid Glass automatically, while iOS and iPadOS 18–25 retain semantic system materials. Content layouts adapt from a focused single column on iPhone to centered, multi-column grids on wider iPad windows, with dedicated layouts for accessibility Dynamic Type sizes.
+
 #### Disclaimer
 
 Craftify for Minecraft ("Craftify") is not an official Minecraft product, it is not approved or associated with Mojang or Microsoft.


### PR DESCRIPTION
## Summary

- add a shared Craftify SwiftUI design system for branded backgrounds, adaptive content widths, cards, headers, status badges, empty states, and floating surfaces
- redesign the recipe library, Search, Chests, Console Commands, More/About, Appearance, Recipe Details, Reports, Support/Privacy, Release Notes, onboarding, and sync overlays
- preserve the user-selected accent and appearance throughout every screen
- adopt native navigation and controls so iOS/iPadOS 26 receives Liquid Glass automatically, with semantic material fallbacks on iOS/iPadOS 18–25
- adapt wide layouts into centered multi-column content instead of scaling up the phone interface
- improve VoiceOver actions and labels, large Dynamic Type layouts, Reduce Motion/Transparency behavior, and dark-mode contrast
- replace the fixed recipe crafting layout with a width-aware horizontal/vertical composition
- update the appearance UI test and document the shared design layer

## Why

Craftify had several individually polished screens, but other areas still relied on generic inset-grouped lists or fixed sizing. This unifies the app around the visual language already present in onboarding, sync, reports, and chest details while keeping the interface native and maintainable.

## Validation

- `git diff --check`
- parsed all Swift app and test sources with the Tree-sitter Swift grammar (no syntax errors)
- confirmed the published Git tree exactly matches the validated local tree
- Xcode 26 build is pending: the connector-created pull request did not automatically start GitHub Actions, so run **Craftify iOS CI** manually with `workflow_dispatch` on `agent/craftify-ui-overhaul`

## Review notes

This remains a draft until the authoritative iOS/iPadOS SDK build completes. The PR keeps data, CloudKit, sync, report, chest, navigation, and appearance behavior intact; its scope is the presentation and interaction layer.