### PR TITLE
Refine Craftify UI consistency and adaptive layouts

### DIFF
--- a/Craftify/AppAppearanceView.swift
+++ b/Craftify/AppAppearanceView.swift
@@ -68,12 +68,10 @@ struct AppAppearanceView: View {
     }
 
     private var iconColumns: [GridItem] {
-        CraftifyLayout.adaptiveColumns(
-            minimum: dynamicTypeSize.isAccessibilitySize ? 280 : 190,
-            maximum: 280,
-            spacing: 14,
-            dynamicTypeSize: dynamicTypeSize
-        )
+        if horizontalSizeClass == .compact || dynamicTypeSize.isAccessibilitySize {
+            return [GridItem(.flexible())]
+        }
+        return [GridItem(.flexible()), GridItem(.flexible())]
     }
 
     var body: some View {
@@ -90,7 +88,7 @@ struct AppAppearanceView: View {
                 accentSection
                 appIconSection
             }
-            .craftifyContentWidth(CraftifyLayout.formMaxWidth)
+            .craftifyContentWidth()
             .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
             .padding(.top, 12)
             .padding(.bottom, 32)
@@ -255,10 +253,10 @@ struct AppAppearanceView: View {
             .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
             .background(
                 selectedAccentColor.opacity(isSelected ? 0.10 : 0.03),
-                in: RoundedRectangle(cornerRadius: 17, style: .continuous)
+                in: RoundedRectangle(cornerRadius: 14, style: .continuous)
             )
             .overlay {
-                RoundedRectangle(cornerRadius: 17, style: .continuous)
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .stroke(selectedAccentColor.opacity(isSelected ? 0.48 : 0.12), lineWidth: isSelected ? 2 : 1)
             }
         }

--- a/Craftify/ChestsView.swift
+++ b/Craftify/ChestsView.swift
@@ -47,7 +47,7 @@ struct ChestsView: View {
                             .buttonStyle(.borderedProminent)
                             .controlSize(.large)
                         }
-                        .craftifyContentWidth(CraftifyLayout.formMaxWidth)
+                        .craftifyContentWidth()
                         .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
                         .padding(.top, 12)
                         .padding(.bottom, 32)
@@ -88,12 +88,12 @@ struct ChestsView: View {
                     }
                     .listStyle(.plain)
                     .scrollContentBackground(.hidden)
-                    .frame(maxWidth: 900)
+                    .frame(maxWidth: CraftifyLayout.contentMaxWidth)
+                    .frame(maxWidth: .infinity)
                     .safeAreaPadding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
                 }
             }
-            .id(accentColorPreference)
-            .tint(Color.userAccentColor)
+            .tint(Color.userAccentColor(for: accentColorPreference))
             .navigationTitle("Chests")
             .navigationBarTitleDisplayMode(.large)
             .toolbar(.visible, for: .navigationBar)
@@ -199,6 +199,7 @@ private struct ChestListRow: View {
     let isEditing: Bool
     let onEdit: () -> Void
     let onDelete: () -> Void
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         rowContent
@@ -209,7 +210,7 @@ private struct ChestListRow: View {
                 Button("Delete", role: .destructive, action: onDelete)
                     .tint(.red)
                 Button("Edit", action: onEdit)
-                    .tint(Color.userAccentColor)
+                    .tint(accent)
             }
             .contextMenu {
                 Button("Edit Chest", systemImage: "pencil", action: onEdit)
@@ -234,21 +235,22 @@ private struct ChestListRow: View {
 
 private struct ChestRow: View {
     let chest: RecipeChest
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         HStack(spacing: 16) {
             Image(systemName: chest.displaySymbol)
                 .font(.title2)
-                .foregroundStyle(Color.userAccentColor)
+                .foregroundStyle(accent)
                 .frame(width: 44, height: 44)
-                .background(Color.userAccentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 12))
+                .background(accent.opacity(0.12), in: RoundedRectangle(cornerRadius: 12))
                 .accessibilityHidden(true)
             VStack(alignment: .leading, spacing: 4) {
                 Text(chest.name).font(.headline)
                 Text("\(chest.recipeIDs.count) of \(chest.size.rawValue) slots")
                     .font(.subheadline).foregroundStyle(.secondary)
                 ProgressView(value: Double(chest.recipeIDs.count), total: Double(chest.size.rawValue))
-                    .tint(Color.userAccentColor)
+                    .tint(accent)
             }
         }
         .accessibilityElement(children: .combine)
@@ -344,7 +346,7 @@ struct ChestDetailView: View {
                     AppBackground()
                         .ignoresSafeArea()
                 }
-                .id(accentColorPreference).tint(Color.userAccentColor)
+                .tint(Color.userAccentColor(for: accentColorPreference))
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbarBackground(.hidden, for: .navigationBar)
                 .toolbar {
@@ -399,6 +401,7 @@ private struct ChestDetailHeader: View {
     let usedSlots: Int
     let isEditing: Bool
     @Binding var name: String
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         ViewThatFits(in: .horizontal) {
@@ -423,8 +426,8 @@ private struct ChestDetailHeader: View {
             .font(.system(.largeTitle, design: .rounded, weight: .bold))
             .foregroundStyle(.white)
             .frame(width: 92, height: 92)
-            .background(Color.userAccentColor.gradient, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
-            .shadow(color: Color.userAccentColor.opacity(0.25), radius: 14, y: 8)
+            .background(accent.gradient, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+            .shadow(color: accent.opacity(0.25), radius: 14, y: 8)
             .accessibilityHidden(true)
     }
 
@@ -450,7 +453,7 @@ private struct ChestDetailHeader: View {
                 .font(.headline)
                 .foregroundStyle(.secondary)
             ProgressView(value: Double(usedSlots), total: Double(chest.size.rawValue))
-                .tint(Color.userAccentColor)
+                .tint(accent)
                 .frame(maxWidth: 400)
                 .accessibilityLabel("Chest capacity")
                 .accessibilityValue("\(usedSlots) of \(chest.size.rawValue) slots used")
@@ -461,6 +464,7 @@ private struct ChestDetailHeader: View {
 
 private struct ChestRecipeCard: View {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
     let recipe: Recipe
     let slot: Int
     var body: some View {
@@ -482,7 +486,7 @@ private struct ChestRecipeCard: View {
                     .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 2)
                 Label(recipe.category, systemImage: "tag.fill")
                     .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color.userAccentColor)
+                    .foregroundStyle(accent)
                     .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
             }
             .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -490,7 +494,7 @@ private struct ChestRecipeCard: View {
             .background(Color(.secondarySystemGroupedBackground))
         }
         .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-        .overlay { RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(Color.userAccentColor.opacity(0.4), lineWidth: 1) }
+        .overlay { RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(accent.opacity(0.4), lineWidth: 1) }
         .shadow(color: .black.opacity(0.08), radius: 8, y: 4)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Slot \(slot), \(recipe.name), \(recipe.category)")
@@ -567,8 +571,7 @@ struct ChestEditorView: View {
             } message: {
                 Text("A small chest holds 27 recipes. Shrinking will permanently remove the last \(overflowCount) recipes from this chest and sync the change to iCloud.")
             }
-            .id(accentColorPreference)
-            .tint(Color.userAccentColor)
+            .tint(Color.userAccentColor(for: accentColorPreference))
             .craftifyNavigationBar()
         }
     }
@@ -627,7 +630,7 @@ struct ChestsTutorialView: View {
                     Text("Your chest room syncs through iCloud, so its order, names, and recipes follow you across devices.")
                         .font(.callout).foregroundStyle(.secondary)
                 }
-                .craftifyContentWidth(CraftifyLayout.readingMaxWidth)
+                .craftifyContentWidth()
                 .padding(24)
             }
             .toolbar { Button("Done") { dismiss() }.fontWeight(.semibold) }

--- a/Craftify/CommandsView.swift
+++ b/Craftify/CommandsView.swift
@@ -160,16 +160,16 @@ private struct CommandCard: View {
     let onCopy: () -> Void
     let onShowOPLevels: () -> Void
 
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
             HStack(alignment: .top, spacing: 12) {
                 Image(systemName: "chevron.left.forwardslash.chevron.right")
-                    .font(.title3.weight(.semibold))
-                    .foregroundStyle(Color.userAccentColor)
-                    .frame(width: 44, height: 44)
-                    .background(Color.userAccentColor.opacity(0.11), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(accent)
+                    .frame(width: 36, height: 36)
+                    .background(accent.opacity(0.11), in: RoundedRectangle(cornerRadius: 10, style: .continuous))
                     .accessibilityHidden(true)
 
                 Text(command.name)
@@ -180,8 +180,8 @@ private struct CommandCard: View {
 
                 Button(action: onCopy) {
                     Image(systemName: isCopied ? "checkmark" : "doc.on.doc")
-                        .font(.body.weight(.semibold))
-                        .frame(width: 36, height: 36)
+                        .font(.subheadline.weight(.semibold))
+                        .frame(width: 30, height: 30)
                 }
                 .buttonStyle(.bordered)
                 .buttonBorderShape(.circle)
@@ -199,7 +199,7 @@ private struct CommandCard: View {
             }
         }
         .padding(16)
-        .frame(maxWidth: .infinity, minHeight: dynamicTypeSize.isAccessibilitySize ? nil : 190, alignment: .topLeading)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
         .craftifyCard(cornerRadius: 20)
         .contextMenu {
             Button("Copy Command", systemImage: "doc.on.doc", action: onCopy)
@@ -228,6 +228,7 @@ private struct CommandEditionBadge: View {
     let isSupported: Bool
     let opLevel: Int64?
     let onShowOPLevels: () -> Void
+    @Environment(\.craftifyAccentColor) private var accent
 
     private var opColor: Color {
         switch opLevel {
@@ -256,11 +257,11 @@ private struct CommandEditionBadge: View {
                     .accessibilityHint("Jumps to the operator level explanation")
             }
         }
-        .foregroundStyle(isSupported ? Color.userAccentColor : Color.red)
+        .foregroundStyle(isSupported ? accent : Color.red)
         .padding(.horizontal, 9)
         .padding(.vertical, 7)
         .background(
-            (isSupported ? Color.userAccentColor : Color.red).opacity(0.08),
+            (isSupported ? accent : Color.red).opacity(0.08),
             in: Capsule()
         )
         .accessibilityElement(children: .contain)
@@ -269,6 +270,8 @@ private struct CommandEditionBadge: View {
 }
 
 private struct OPLevelsCard: View {
+    @Environment(\.craftifyAccentColor) private var accent
+
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
             CraftifySectionHeader(
@@ -315,7 +318,7 @@ private struct OPLevelsCard: View {
         VStack(alignment: .leading, spacing: 11) {
             Label(title, systemImage: symbol)
                 .font(.headline)
-                .foregroundStyle(Color.userAccentColor)
+                .foregroundStyle(accent)
             ForEach(levels, id: \.0) { level in
                 VStack(alignment: .leading, spacing: 2) {
                     Text(level.0).font(.subheadline.bold())

--- a/Craftify/ContentView.swift
+++ b/Craftify/ContentView.swift
@@ -105,22 +105,27 @@ struct ContentView: View {
 
 struct RecipesTabView: View {
     @EnvironmentObject private var dataManager: DataManager
+    @Environment(\.craftifyAccentColor) private var accent
     @Binding var navigationPath: NavigationPath
 
     var body: some View {
         NavigationStack(path: $navigationPath) {
-            CategoryView()
-                .navigationTitle("Craftify")
-                .navigationBarTitleDisplayMode(.large)
-                .toolbarBackground(.hidden, for: .navigationBar)
-                .overlay {
-                    if dataManager.isLoading && dataManager.recipes.isEmpty {
-                        loadingState
+            ZStack {
+                AppBackground().ignoresSafeArea()
+
+                CategoryView()
+                    .navigationTitle("Craftify")
+                    .navigationBarTitleDisplayMode(.large)
+                    .toolbarBackground(.hidden, for: .navigationBar)
+                    .overlay {
+                        if dataManager.isLoading && dataManager.recipes.isEmpty {
+                            loadingState
+                        }
                     }
-                }
-                .navigationDestination(for: Recipe.self) { recipe in
-                    RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
-                }
+                    .navigationDestination(for: Recipe.self) { recipe in
+                        RecipeDetailView(recipe: recipe, navigationPath: $navigationPath)
+                    }
+            }
         }
         .dynamicTypeSize(.xSmall ... .accessibility5)
     }
@@ -130,7 +135,7 @@ struct RecipesTabView: View {
             CraftifyAppMark(size: 72)
             ProgressView()
                 .controlSize(.large)
-                .tint(Color.userAccentColor)
+                .tint(accent)
                 .accessibilityHidden(true)
             Text("Preparing Your Recipe Book")
                 .font(.headline)
@@ -166,7 +171,6 @@ struct CategoryView: View {
                 filteredRecipes: filteredRecipes
             )
         }
-        .background(alignment: .top) { AppHeroBackground(additionalHeight: 92) }
         .navigationTitle("Craftify")
         .navigationBarTitleDisplayMode(.large)
         .onAppear {
@@ -204,6 +208,10 @@ struct CategoryFilterBar: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
 
+    private var accent: Color {
+        Color.userAccentColor(for: accentColorPreference)
+    }
+
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
@@ -217,7 +225,6 @@ struct CategoryFilterBar: View {
         .craftifyFloatingSurface(cornerRadius: 18)
         .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
         .padding(.bottom, 8)
-        .id(accentColorPreference)
         .accessibilityLabel("Recipe categories")
     }
 
@@ -234,7 +241,7 @@ struct CategoryFilterBar: View {
                 .padding(.horizontal, horizontalSizeClass == .regular ? 15 : 12)
                 .padding(.vertical, 9)
                 .background(
-                    isSelected ? Color.userAccentColor : Color.primary.opacity(0.055),
+                    isSelected ? accent : Color.primary.opacity(0.055),
                     in: Capsule()
                 )
         }
@@ -244,46 +251,11 @@ struct CategoryFilterBar: View {
     }
 }
 
-struct AppHeroBackground: View {
-    let additionalHeight: CGFloat?
-    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
-
-    init(additionalHeight: CGFloat? = 0) {
-        self.additionalHeight = additionalHeight
-    }
-
-    var body: some View {
-        GeometryReader { geometry in
-            let navigationHeight = max(
-                geometry.safeAreaInsets.top,
-                max(geometry.frame(in: .global).minY, 0)
-            )
-            let height = additionalHeight.map { navigationHeight + $0 }
-                ?? geometry.size.height + navigationHeight
-
-            ZStack(alignment: .top) {
-                AppBackground()
-                LinearGradient(
-                    colors: [
-                        Color.userAccentColor(for: accentColorPreference).opacity(0.32),
-                        Color.userAccentColor(for: accentColorPreference).opacity(0.10),
-                        .clear
-                    ],
-                    startPoint: .topLeading,
-                    endPoint: .bottomTrailing
-                )
-                .frame(height: height)
-            }
-        }
-        .ignoresSafeArea(edges: .top)
-        .accessibilityHidden(true)
-    }
-}
-
 struct RecipeListView: View {
     @EnvironmentObject private var dataManager: DataManager
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
     @Binding var recommendedRecipes: [Recipe]
     @Binding var isCraftifyPicksExpanded: Bool
     let filteredRecipes: [String: [Recipe]]
@@ -323,7 +295,6 @@ struct RecipeListView: View {
                 .scrollIndicators(.hidden)
             }
         }
-        .background { AppBackground().ignoresSafeArea() }
     }
 
     private var picksSection: some View {
@@ -354,7 +325,7 @@ struct RecipeListView: View {
         VStack(alignment: .leading, spacing: 10) {
             Text(letter)
                 .font(.title2.bold())
-                .foregroundStyle(Color.userAccentColor)
+                .foregroundStyle(accent)
                 .accessibilityAddTraits(.isHeader)
 
             LazyVGrid(columns: recipeColumns, alignment: .leading, spacing: 12) {
@@ -375,16 +346,18 @@ struct RecipeCell: View {
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         Group {
             if isCraftifyPick {
                 pickContent
+                    .craftifyAccentCard(cornerRadius: 18)
             } else {
                 rowContent
+                    .craftifyCard(cornerRadius: 18)
             }
         }
-        .craftifyCard(cornerRadius: 18)
         .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(recipe.name), \(recipe.category.isEmpty ? "recipe" : "\(recipe.category) recipe")")
@@ -403,7 +376,7 @@ struct RecipeCell: View {
                 if !recipe.category.isEmpty {
                     Label(recipe.category, systemImage: "tag.fill")
                         .font(.caption.weight(.semibold))
-                        .foregroundStyle(Color.userAccentColor)
+                        .foregroundStyle(accent)
                         .lineLimit(dynamicTypeSize.isAccessibilitySize ? nil : 1)
                 }
             }
@@ -420,7 +393,6 @@ struct RecipeCell: View {
     private var pickContent: some View {
         VStack(alignment: .leading, spacing: 10) {
             ZStack(alignment: .topLeading) {
-                AppBackground()
                 recipeImage(size: horizontalSizeClass == .regular ? 96 : 82)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                     .padding(10)
@@ -428,7 +400,6 @@ struct RecipeCell: View {
                     .padding(9)
             }
             .frame(height: horizontalSizeClass == .regular ? 142 : 124)
-            .clipShape(RoundedRectangle(cornerRadius: 17, style: .continuous))
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(recipe.name)
@@ -451,7 +422,7 @@ struct RecipeCell: View {
             .scaledToFit()
             .frame(width: size, height: size)
             .padding(5)
-            .background(Color.userAccentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+            .background(accent.opacity(0.08), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
             .accessibilityHidden(true)
     }
 }
@@ -459,12 +430,13 @@ struct RecipeCell: View {
 struct CraftifyPicksHeader: View {
     let isExpanded: Bool
     let toggle: () -> Void
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         Button(action: toggle) {
             HStack(spacing: 10) {
                 Image(systemName: "sparkles")
-                    .foregroundStyle(Color.userAccentColor)
+                    .foregroundStyle(accent)
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Craftify Picks")
                         .font(.title3.bold())
@@ -476,7 +448,7 @@ struct CraftifyPicksHeader: View {
                 Spacer()
                 Image(systemName: isExpanded ? "chevron.up.circle.fill" : "chevron.down.circle.fill")
                     .font(.title3)
-                    .foregroundStyle(Color.userAccentColor)
+                    .foregroundStyle(accent)
             }
             .contentShape(Rectangle())
         }

--- a/Craftify/CraftifyApp.swift
+++ b/Craftify/CraftifyApp.swift
@@ -18,6 +18,8 @@ struct CraftifyApp: App {
 
     var body: some Scene {
         WindowGroup {
+            let accent = Color.userAccentColor(for: accentColorPreference)
+
             ZStack {
                 ContentView()
                     .environmentObject(dataManager)
@@ -45,7 +47,8 @@ struct CraftifyApp: App {
                     .zIndex(1)
                 }
             }
-            .tint(Color.userAccentColor)
+            .tint(accent)
+            .environment(\.craftifyAccentColor, accent)
             .dynamicTypeSize(.xSmall ... .accessibility5)
             .onAppear {
                 dataManager.fetchRecipes(

--- a/Craftify/CraftifyDesignSystem.swift
+++ b/Craftify/CraftifyDesignSystem.swift
@@ -7,10 +7,19 @@
 
 import SwiftUI
 
+private struct CraftifyAccentColorKey: EnvironmentKey {
+    static let defaultValue = Color.userAccentColor
+}
+
+extension EnvironmentValues {
+    var craftifyAccentColor: Color {
+        get { self[CraftifyAccentColorKey.self] }
+        set { self[CraftifyAccentColorKey.self] = newValue }
+    }
+}
+
 enum CraftifyLayout {
     static let contentMaxWidth: CGFloat = 1_180
-    static let readingMaxWidth: CGFloat = 760
-    static let formMaxWidth: CGFloat = 820
 
     static func pagePadding(for sizeClass: UserInterfaceSizeClass?) -> CGFloat {
         sizeClass == .regular ? 28 : 16
@@ -32,13 +41,9 @@ enum CraftifyLayout {
 /// The app-wide canvas. The restrained 3×3 block motifs reference the
 /// crafting grid without turning every screen into a Minecraft texture.
 struct AppBackground: View {
-    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
+    @Environment(\.craftifyAccentColor) private var accent
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
     @Environment(\.colorScheme) private var colorScheme
-
-    private var accent: Color {
-        Color.userAccentColor(for: accentColorPreference)
-    }
 
     var body: some View {
         ZStack {
@@ -72,11 +77,9 @@ struct AppBackground: View {
 }
 
 private struct CraftifyBlockMotif: View {
-    @AppStorage("accentColorPreference") private var accentColorPreference = "default"
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
-        let accent = Color.userAccentColor(for: accentColorPreference)
-
         LazyVGrid(
             columns: Array(repeating: GridItem(.flexible(), spacing: 7), count: 3),
             spacing: 7
@@ -94,6 +97,7 @@ struct CraftifyIconTile: View {
     let symbol: String
     var size: CGFloat = 56
     var destructive = false
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         Image(systemName: symbol)
@@ -101,11 +105,11 @@ struct CraftifyIconTile: View {
             .foregroundStyle(.white)
             .frame(width: size, height: size)
             .background(
-                destructive ? Color.red.gradient : Color.userAccentColor.gradient,
+                destructive ? Color.red.gradient : accent.gradient,
                 in: RoundedRectangle(cornerRadius: size * 0.28, style: .continuous)
             )
             .shadow(
-                color: (destructive ? Color.red : Color.userAccentColor).opacity(0.20),
+                color: (destructive ? Color.red : accent).opacity(0.20),
                 radius: 10,
                 y: 5
             )
@@ -115,17 +119,18 @@ struct CraftifyIconTile: View {
 
 struct CraftifyAppMark: View {
     var size: CGFloat = 88
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         ZStack {
             RoundedRectangle(cornerRadius: size * 0.25, style: .continuous)
-                .fill(Color.userAccentColor.gradient)
+                .fill(accent.gradient)
             Image(systemName: "hammer.fill")
                 .font(.system(size: size * 0.43, weight: .bold))
                 .foregroundStyle(.white)
         }
         .frame(width: size, height: size)
-        .shadow(color: Color.userAccentColor.opacity(0.24), radius: 16, y: 8)
+        .shadow(color: accent.opacity(0.24), radius: 16, y: 8)
         .accessibilityHidden(true)
     }
 }
@@ -137,6 +142,7 @@ struct CraftifyHero: View {
     let symbol: String
 
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
 
     init(eyebrow: String? = nil, title: String, detail: String, symbol: String) {
         self.eyebrow = eyebrow
@@ -182,7 +188,7 @@ struct CraftifyHero: View {
                 Text(eyebrow.uppercased())
                     .font(.caption.weight(.bold))
                     .tracking(1.1)
-                    .foregroundStyle(Color.userAccentColor)
+                    .foregroundStyle(accent)
             }
             Text(title)
                 .font(.title2.bold())
@@ -252,21 +258,31 @@ struct CraftifyEmptyState: View {
 struct CraftifyStatusPill: View {
     let title: String
     let symbol: String
-    var tint: Color = Color.userAccentColor
+    var tint: Color?
+    @Environment(\.craftifyAccentColor) private var accent
+
+    init(title: String, symbol: String, tint: Color? = nil) {
+        self.title = title
+        self.symbol = symbol
+        self.tint = tint
+    }
 
     var body: some View {
+        let resolvedTint = tint ?? accent
+
         Label(title, systemImage: symbol)
             .font(.caption.weight(.semibold))
-            .foregroundStyle(tint)
+            .foregroundStyle(resolvedTint)
             .padding(.horizontal, 10)
             .padding(.vertical, 7)
-            .background(tint.opacity(0.12), in: Capsule())
+            .background(resolvedTint.opacity(0.12), in: Capsule())
     }
 }
 
 private struct CraftifyCardModifier: ViewModifier {
     let cornerRadius: CGFloat
     @Environment(\.colorSchemeContrast) private var contrast
+    @Environment(\.craftifyAccentColor) private var accent
 
     func body(content: Content) -> some View {
         content
@@ -277,7 +293,30 @@ private struct CraftifyCardModifier: ViewModifier {
             .overlay {
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
                     .stroke(
-                        Color.userAccentColor.opacity(contrast == .increased ? 0.42 : 0.16),
+                        accent.opacity(contrast == .increased ? 0.42 : 0.16),
+                        lineWidth: contrast == .increased ? 1.5 : 1
+                    )
+            }
+            .shadow(color: .black.opacity(0.055), radius: 12, y: 5)
+    }
+}
+
+private struct CraftifyAccentCardModifier: ViewModifier {
+    let cornerRadius: CGFloat
+    @Environment(\.colorSchemeContrast) private var contrast
+    @Environment(\.craftifyAccentColor) private var accent
+
+    func body(content: Content) -> some View {
+        content
+            .background {
+                AppBackground()
+                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            }
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(
+                        accent.opacity(contrast == .increased ? 0.48 : 0.20),
                         lineWidth: contrast == .increased ? 1.5 : 1
                     )
             }
@@ -289,12 +328,16 @@ private struct CraftifyFloatingSurfaceModifier: ViewModifier {
     let cornerRadius: CGFloat
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
 
+    private var accent: Color {
+        Color.userAccentColor(for: accentColorPreference)
+    }
+
     @ViewBuilder
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
             content
                 .glassEffect(
-                    .regular.tint(Color.userAccentColor(for: accentColorPreference).opacity(0.08)),
+                    .regular.tint(accent.opacity(0.08)),
                     in: .rect(cornerRadius: cornerRadius)
                 )
         } else {
@@ -305,7 +348,7 @@ private struct CraftifyFloatingSurfaceModifier: ViewModifier {
                 )
                 .overlay {
                     RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                        .stroke(Color.userAccentColor.opacity(0.18), lineWidth: 1)
+                        .stroke(accent.opacity(0.18), lineWidth: 1)
                 }
         }
     }
@@ -326,10 +369,16 @@ private struct CraftifyPageModifier: ViewModifier {
     @AppStorage("accentColorPreference") private var accentColorPreference = "default"
 
     func body(content: Content) -> some View {
+        let accent = Color.userAccentColor(for: accentColorPreference)
+
         content
-            .background { AppBackground().ignoresSafeArea() }
-            .tint(Color.userAccentColor(for: accentColorPreference))
-            .id(accentColorPreference)
+            .background {
+                AppBackground()
+                    .environment(\.craftifyAccentColor, accent)
+                    .ignoresSafeArea()
+            }
+            .tint(accent)
+            .environment(\.craftifyAccentColor, accent)
             .modifier(CraftifyNavigationBarModifier())
             .dynamicTypeSize(.xSmall ... .accessibility5)
     }
@@ -338,6 +387,10 @@ private struct CraftifyPageModifier: ViewModifier {
 extension View {
     func craftifyCard(cornerRadius: CGFloat = 20) -> some View {
         modifier(CraftifyCardModifier(cornerRadius: cornerRadius))
+    }
+
+    func craftifyAccentCard(cornerRadius: CGFloat = 20) -> some View {
+        modifier(CraftifyAccentCardModifier(cornerRadius: cornerRadius))
     }
 
     func craftifyFloatingSurface(cornerRadius: CGFloat = 24) -> some View {
@@ -355,5 +408,9 @@ extension View {
     func craftifyContentWidth(_ maximum: CGFloat = CraftifyLayout.contentMaxWidth) -> some View {
         frame(maxWidth: maximum)
             .frame(maxWidth: .infinity)
+    }
+
+    func craftifyButtonBorder(cornerRadius: CGFloat = 16) -> some View {
+        buttonBorderShape(.roundedRectangle(radius: cornerRadius))
     }
 }

--- a/Craftify/DataManager.swift
+++ b/Craftify/DataManager.swift
@@ -27,7 +27,7 @@ final class DataManager: ObservableObject {
     enum RecipeBookLoadingPhase: Equatable {
         case idle
         case downloadingRecipes(downloaded: Int, total: Int?)
-        case preparingImages(prepared: Int, total: Int)
+        case preparingImages(prepared: Int, total: Int, recipeTotal: Int)
     }
 
     struct NewRecipeAnnouncement: Identifiable, Equatable {
@@ -419,7 +419,8 @@ final class DataManager: ObservableObject {
                     let imageCount = CraftImageStore.imageKeys(in: fetchedRecipes).count
                     recipeBookLoadingPhase = .preparingImages(
                         prepared: 0,
-                        total: imageCount
+                        total: imageCount,
+                        recipeTotal: actualRecipeCount
                     )
                     let allImagesPrepared = await imageStore.prepare(
                         recipes: fetchedRecipes
@@ -429,7 +430,8 @@ final class DataManager: ObservableObject {
                         }
                         self.recipeBookLoadingPhase = .preparingImages(
                             prepared: prepared,
-                            total: total
+                            total: total,
+                            recipeTotal: actualRecipeCount
                         )
                     }
                     guard generation == recipeFetchGeneration else { return }
@@ -441,6 +443,14 @@ final class DataManager: ObservableObject {
                         isManualSyncing = false
                         return
                     }
+
+                    recipeBookLoadingPhase = .preparingImages(
+                        prepared: imageCount,
+                        total: imageCount,
+                        recipeTotal: actualRecipeCount
+                    )
+                    try? await Task.sleep(for: .milliseconds(300))
+                    guard generation == recipeFetchGeneration else { return }
                 } else {
                     imageStore.prefetch(recipes: fetchedRecipes)
                 }

--- a/Craftify/MoreView.swift
+++ b/Craftify/MoreView.swift
@@ -108,7 +108,7 @@ struct MoreView: View {
             HStack(alignment: .top, spacing: 14) {
                 CraftifyIconTile(
                     symbol: dataManager.isConnected ? "icloud.and.arrow.down.fill" : "icloud.slash.fill",
-                    size: 58
+                    size: 48
                 )
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Recipe Book Sync")
@@ -133,11 +133,11 @@ struct MoreView: View {
                     dataManager.isLoading ? "Syncing Recipes & Images…" : "Sync Recipes & Images",
                     systemImage: dataManager.isLoading ? "hourglass" : "arrow.clockwise"
                 )
-                .font(.headline)
-                .frame(maxWidth: .infinity, minHeight: 48)
+                .font(.subheadline.weight(.semibold))
+                .frame(maxWidth: .infinity, minHeight: 42)
             }
             .buttonStyle(.borderedProminent)
-            .controlSize(.large)
+            .craftifyButtonBorder(cornerRadius: 16)
             .disabled(dataManager.isLoading || !dataManager.isConnected || remainingCooldownTime > 0)
             .accessibilityHint(syncHint)
 
@@ -158,7 +158,7 @@ struct MoreView: View {
                 .foregroundStyle(.orange)
             }
         }
-        .padding(20)
+        .padding(18)
         .craftifyCard(cornerRadius: 24)
     }
 
@@ -259,6 +259,7 @@ struct MoreView: View {
 struct AboutView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
 
     private var appVersion: String {
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
@@ -267,37 +268,27 @@ struct AboutView: View {
     }
 
     private var linkColumns: [GridItem] {
-        CraftifyLayout.adaptiveColumns(
-            minimum: dynamicTypeSize.isAccessibilitySize ? 280 : 240,
-            maximum: 360,
-            spacing: 14,
-            dynamicTypeSize: dynamicTypeSize
-        )
+        if horizontalSizeClass == .compact || dynamicTypeSize.isAccessibilitySize {
+            return [GridItem(.flexible())]
+        }
+        return [GridItem(.flexible()), GridItem(.flexible())]
     }
 
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 24) {
-                VStack(spacing: 14) {
-                    Image("AppIconPreview")
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: horizontalSizeClass == .regular ? 112 : 94)
-                        .clipShape(RoundedRectangle(cornerRadius: 23, style: .continuous))
-                        .shadow(color: Color.userAccentColor.opacity(0.20), radius: 16, y: 8)
-                        .accessibilityLabel("Craftify app icon")
-
-                    Text("Craftify for Minecraft")
-                        .font(.largeTitle.bold())
-                        .multilineTextAlignment(.center)
-                    Text(appVersion)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(Color.userAccentColor)
-                    Text("A focused crafting companion for discovering recipes and planning projects in synced chests.")
-                        .font(.body)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-                        .frame(maxWidth: 560)
+                Group {
+                    if dynamicTypeSize.isAccessibilitySize {
+                        aboutIdentityVertical
+                    } else {
+                        ViewThatFits(in: .horizontal) {
+                            HStack(spacing: 22) {
+                                appIcon
+                                aboutIdentityCopy(alignment: .leading)
+                            }
+                            aboutIdentityVertical
+                        }
+                    }
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.horizontal, 24)
@@ -336,7 +327,7 @@ struct AboutView: View {
                 .padding(16)
                 .craftifyCard(cornerRadius: 18)
             }
-            .craftifyContentWidth(CraftifyLayout.formMaxWidth)
+            .craftifyContentWidth()
             .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
             .padding(.top, 12)
             .padding(.bottom, 32)
@@ -344,6 +335,40 @@ struct AboutView: View {
         .navigationTitle("About Craftify")
         .navigationBarTitleDisplayMode(.large)
         .craftifyPage()
+    }
+
+    private var appIcon: some View {
+        Image("AppIconPreview")
+            .resizable()
+            .scaledToFit()
+            .frame(width: horizontalSizeClass == .regular ? 112 : 94)
+            .clipShape(RoundedRectangle(cornerRadius: 23, style: .continuous))
+            .shadow(color: accent.opacity(0.20), radius: 16, y: 8)
+            .accessibilityLabel("Craftify app icon")
+    }
+
+    private var aboutIdentityVertical: some View {
+        VStack(spacing: 14) {
+            appIcon
+            aboutIdentityCopy(alignment: .center)
+        }
+    }
+
+    private func aboutIdentityCopy(alignment: TextAlignment) -> some View {
+        VStack(alignment: alignment == .center ? .center : .leading, spacing: 7) {
+            Text("Craftify for Minecraft")
+                .font(.largeTitle.bold())
+                .multilineTextAlignment(alignment)
+            Text(appVersion)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(accent)
+            Text("A focused crafting companion for discovering recipes and planning projects in synced chests.")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(alignment)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: alignment == .center ? .center : .leading)
     }
 
     private func aboutDestination<Destination: View>(

--- a/Craftify/OnboardingView.swift
+++ b/Craftify/OnboardingView.swift
@@ -40,8 +40,7 @@ struct OnboardingView: View {
                     .transition(.opacity.combined(with: .scale(scale: 0.98)))
             }
         }
-        .id(accentColorPreference)
-        .tint(Color.userAccentColor)
+        .tint(Color.userAccentColor(for: accentColorPreference))
         .dynamicTypeSize(.xSmall ... .accessibility5)
         .mask {
             SlidingDoorMask(progress: isFinishing && !reduceMotion ? 1 : 0)
@@ -120,7 +119,7 @@ struct OnboardingView: View {
         VStack(spacing: 12) {
             ProgressView()
                 .controlSize(.large)
-                .tint(Color.userAccentColor)
+                .tint(Color.userAccentColor(for: accentColorPreference))
                 .accessibilityHidden(true)
 
             switch dataManager.recipeBookLoadingPhase {
@@ -133,20 +132,12 @@ struct OnboardingView: View {
             case .downloadingRecipes(let downloaded, let total):
                 if let total {
                     let displayedTotal = max(total, downloaded)
-                    ProgressView(
-                        value: Double(downloaded),
-                        total: Double(max(displayedTotal, 1))
+                    loadingProgressRow(
+                        title: "Recipes",
+                        symbol: "book.closed.fill",
+                        completed: downloaded,
+                        total: displayedTotal
                     )
-                    .progressViewStyle(.linear)
-                    .accessibilityHidden(true)
-                    Text("Downloading recipes \(downloaded) / \(displayedTotal)")
-                        .font(.footnote.weight(.medium))
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                        .contentTransition(.numericText())
-                        .accessibilityLabel(
-                            "\(downloaded) of \(displayedTotal) recipes downloaded"
-                        )
                 } else {
                     Text("Downloading recipes… \(downloaded)")
                         .font(.footnote.weight(.medium))
@@ -156,23 +147,51 @@ struct OnboardingView: View {
                         .accessibilityLabel("\(downloaded) recipes downloaded")
                 }
 
-            case .preparingImages(let prepared, let total):
-                ProgressView(
-                    value: Double(total == 0 ? 1 : prepared),
-                    total: Double(max(total, 1))
+            case .preparingImages(let prepared, let total, let recipeTotal):
+                loadingProgressRow(
+                    title: "Recipes",
+                    symbol: "book.closed.fill",
+                    completed: recipeTotal,
+                    total: recipeTotal
                 )
-                .progressViewStyle(.linear)
-                .accessibilityHidden(true)
-                Text("Preparing images \(prepared) / \(total)")
-                    .font(.footnote.weight(.medium))
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
-                    .contentTransition(.numericText())
-                    .accessibilityLabel("\(prepared) of \(total) images prepared")
+                loadingProgressRow(
+                    title: "Images",
+                    symbol: "photo.stack.fill",
+                    completed: prepared,
+                    total: total
+                )
             }
         }
-        .frame(maxWidth: 320)
+        .frame(maxWidth: 360)
         .animation(.easeInOut(duration: 0.25), value: dataManager.recipeBookLoadingPhase)
+    }
+
+    private func loadingProgressRow(
+        title: String,
+        symbol: String,
+        completed: Int,
+        total: Int
+    ) -> some View {
+        let safeTotal = max(total, 1)
+        let safeCompleted = total == 0 ? safeTotal : min(completed, safeTotal)
+
+        return VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                Label(title, systemImage: symbol)
+                    .font(.footnote.weight(.semibold))
+                Spacer()
+                Text("\(completed) / \(total)")
+                    .font(.footnote.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.numericText())
+            }
+
+            ProgressView(value: Double(safeCompleted), total: Double(safeTotal))
+                .progressViewStyle(.linear)
+                .accessibilityHidden(true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(completed) of \(total) \(title.lowercased()) prepared")
     }
 
     private var onboardingPages: some View {
@@ -454,6 +473,8 @@ private struct SlidingDoorMask: Shape {
 }
 
 private struct CraftifyBlockGlow: View {
+    @Environment(\.craftifyAccentColor) private var accent
+
     var body: some View {
         LazyVGrid(
             columns: Array(repeating: GridItem(.flexible(), spacing: 10), count: 3),
@@ -461,7 +482,7 @@ private struct CraftifyBlockGlow: View {
         ) {
             ForEach(0..<9, id: \.self) { index in
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(Color.userAccentColor.opacity(index == 4 ? 0.18 : 0.08))
+                    .fill(accent.opacity(index == 4 ? 0.18 : 0.08))
                     .aspectRatio(1, contentMode: .fit)
             }
         }
@@ -471,14 +492,16 @@ private struct CraftifyBlockGlow: View {
 }
 
 private struct CraftifyPrimaryButtonStyle: ButtonStyle {
+    @Environment(\.craftifyAccentColor) private var accent
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.headline)
             .foregroundStyle(.white)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 14)
-            .background(Color.userAccentColor.gradient, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .shadow(color: Color.userAccentColor.opacity(configuration.isPressed ? 0.12 : 0.25), radius: 10, y: 5)
+            .background(accent.gradient, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .shadow(color: accent.opacity(configuration.isPressed ? 0.12 : 0.25), radius: 10, y: 5)
             .scaleEffect(configuration.isPressed ? 0.98 : 1)
             .animation(.easeInOut(duration: 0.25), value: configuration.isPressed)
     }

--- a/Craftify/RecipeDetailView.swift
+++ b/Craftify/RecipeDetailView.swift
@@ -10,13 +10,11 @@ import SwiftUI
 enum SelectedItem: Equatable {
     case grid(index: Int)
     case output
-    case imageremark
 }
 
 struct RecipeDetailView: View {
     @EnvironmentObject private var dataManager: DataManager
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     let recipe: Recipe
@@ -64,19 +62,14 @@ struct RecipeDetailView: View {
                         detail: selectedDetail,
                         selectedDetail: $selectedDetail,
                         selectedItem: $selectedItem,
-                        recipe: recipe,
                         navigationPath: $navigationPath
                     )
                     .transition(reduceMotion ? .opacity : .scale(scale: 0.97).combined(with: .opacity))
                 }
 
-                RemarkAndCategoryView(
-                    recipe: recipe,
-                    selectedItem: $selectedItem,
-                    selectedDetail: $selectedDetail
-                )
+                RemarkAndCategoryView(recipe: recipe)
             }
-            .craftifyContentWidth(horizontalSizeClass == .regular ? 980 : CraftifyLayout.formMaxWidth)
+            .craftifyContentWidth()
             .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
             .padding(.top, 12)
             .padding(.bottom, 36)
@@ -144,6 +137,7 @@ private struct RecipeIdentityHeader: View {
     let recipe: Recipe
     let output: Int
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         Group {
@@ -183,7 +177,7 @@ private struct RecipeIdentityHeader: View {
         .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
         .overlay {
             RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .stroke(Color.userAccentColor.opacity(0.24), lineWidth: 1)
+                .stroke(accent.opacity(0.24), lineWidth: 1)
         }
         .accessibilityHidden(true)
     }
@@ -193,7 +187,7 @@ private struct RecipeIdentityHeader: View {
             Text("CRAFTING RECIPE")
                 .font(.caption.bold())
                 .tracking(1.1)
-                .foregroundStyle(Color.userAccentColor)
+                .foregroundStyle(accent)
             Text(recipe.name)
                 .font(.largeTitle.bold())
                 .multilineTextAlignment(alignment)
@@ -217,6 +211,7 @@ private struct RecipeIdentityHeader: View {
 private struct AddRecipeToChestView: View {
     @EnvironmentObject private var dataManager: DataManager
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.craftifyAccentColor) private var accent
     let recipe: Recipe
     @State private var creatingChest = false
     @State private var message: String?
@@ -239,14 +234,14 @@ private struct AddRecipeToChestView: View {
                             } label: {
                                 HStack(spacing: 12) {
                                     Image(systemName: chest.displaySymbol)
-                                        .foregroundStyle(Color.userAccentColor)
+                                        .foregroundStyle(accent)
                                     VStack(alignment: .leading, spacing: 3) {
                                         Text(chest.name).foregroundStyle(.primary)
                                         ProgressView(
                                             value: Double(chest.recipeIDs.count),
                                             total: Double(chest.size.rawValue)
                                         )
-                                        .tint(Color.userAccentColor)
+                                        .tint(accent)
                                     }
                                     Text("\(chest.recipeIDs.count)/\(chest.size.rawValue)")
                                         .font(.caption.monospacedDigit())
@@ -308,6 +303,7 @@ struct AlternateRecipesSelector: View {
     @Binding var selectedCraftingOption: Int
     @Binding var selectedDetail: String?
     @Binding var selectedItem: SelectedItem?
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         if ingredientSets.count > 1 {
@@ -332,7 +328,7 @@ struct AlternateRecipesSelector: View {
                             .padding(.horizontal, 15)
                             .padding(.vertical, 9)
                             .background(
-                                isSelected ? Color.userAccentColor : Color.primary.opacity(0.06),
+                                isSelected ? accent : Color.primary.opacity(0.06),
                                 in: Capsule()
                             )
                             .buttonStyle(.plain)
@@ -357,6 +353,7 @@ private struct CraftingRecipeCard: View {
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
 
     private var cellSize: CGFloat {
         horizontalSizeClass == .regular ? 76 : 64
@@ -388,7 +385,7 @@ private struct CraftingRecipeCard: View {
             craftingGrid
             Image(systemName: "arrow.right")
                 .font(.title.bold())
-                .foregroundStyle(Color.userAccentColor)
+                .foregroundStyle(accent)
                 .accessibilityHidden(true)
             outputTile
         }
@@ -400,7 +397,7 @@ private struct CraftingRecipeCard: View {
             craftingGrid
             Image(systemName: "arrow.down")
                 .font(.title2.bold())
-                .foregroundStyle(Color.userAccentColor)
+                .foregroundStyle(accent)
                 .accessibilityHidden(true)
             outputTile
         }
@@ -435,11 +432,11 @@ private struct CraftingRecipeCard: View {
             VStack(spacing: 7) {
                 ZStack {
                     RoundedRectangle(cornerRadius: 15, style: .continuous)
-                        .fill(Color.userAccentColor.opacity(0.09))
+                        .fill(accent.opacity(0.09))
                         .overlay {
                             RoundedRectangle(cornerRadius: 15, style: .continuous)
                                 .stroke(
-                                    selectedItem == .output ? Color.userAccentColor : Color.userAccentColor.opacity(0.18),
+                                    selectedItem == .output ? accent : accent.opacity(0.18),
                                     lineWidth: selectedItem == .output ? 2 : 1
                                 )
                         }
@@ -464,9 +461,10 @@ struct IngredientDetailPopup: View {
     let detail: String
     @Binding var selectedDetail: String?
     @Binding var selectedItem: SelectedItem?
-    let recipe: Recipe
     @Binding var navigationPath: NavigationPath
     @EnvironmentObject private var dataManager: DataManager
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
 
     private var subRecipe: Recipe? {
         guard case .grid(_) = selectedItem else { return nil }
@@ -476,31 +474,21 @@ struct IngredientDetailPopup: View {
     private var descriptor: String {
         switch selectedItem {
         case .output: "Crafting output"
-        case .imageremark: recipe.remarks?.isEmpty == false ? recipe.remarks! : "Crafting utility"
         case .grid: "Crafting ingredient"
         case nil: "Recipe detail"
         }
     }
 
     var body: some View {
-        VStack(spacing: 16) {
-            HStack(alignment: .top, spacing: 14) {
-                CraftImage(key: detail)
-                    .scaledToFit()
-                    .frame(width: 76, height: 76)
-                    .padding(8)
-                    .background(Color.userAccentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-                    .accessibilityHidden(true)
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 12) {
+                Text(descriptor.uppercased())
+                    .font(.caption.bold())
+                    .tracking(1)
+                    .foregroundStyle(accent)
 
-                VStack(alignment: .leading, spacing: 5) {
-                    Text(detail)
-                        .font(.title2.bold())
-                    Text(descriptor)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-                Spacer(minLength: 4)
+                Spacer(minLength: 8)
+
                 Button("Close", systemImage: "xmark.circle.fill") {
                     selectedDetail = nil
                     selectedItem = nil
@@ -511,25 +499,71 @@ struct IngredientDetailPopup: View {
                 .accessibilityHint("Dismisses these details")
             }
 
+            Group {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(alignment: .leading, spacing: 14) {
+                        detailImage
+                        detailTitle
+                    }
+                } else {
+                    ViewThatFits(in: .horizontal) {
+                        HStack(alignment: .center, spacing: 16) {
+                            detailImage
+                            detailTitle
+                        }
+                        VStack(alignment: .leading, spacing: 14) {
+                            detailImage
+                            detailTitle
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
             if let subRecipe {
-                Button("View \(subRecipe.name) Recipe", systemImage: "arrow.right.circle.fill") {
+                Button {
                     navigationPath.append(subRecipe)
+                } label: {
+                    Label("View \(subRecipe.name) Recipe", systemImage: "arrow.right.circle.fill")
+                        .font(.headline)
+                        .frame(maxWidth: .infinity, minHeight: 44)
                 }
                 .buttonStyle(.borderedProminent)
-                .controlSize(.large)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .craftifyButtonBorder(cornerRadius: 16)
             }
         }
         .padding(18)
         .craftifyCard(cornerRadius: 22)
         .accessibilityElement(children: .contain)
     }
+
+    private var detailImage: some View {
+        CraftImage(key: detail)
+            .scaledToFit()
+            .frame(width: 76, height: 76)
+            .padding(8)
+            .background(accent.opacity(0.08), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+            .accessibilityHidden(true)
+    }
+
+    private var detailTitle: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(detail)
+                .font(.title2.bold())
+                .fixedSize(horizontal: false, vertical: true)
+            Text(selectedItem == .output ? "The item produced by this recipe." : "An item required in the crafting layout.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
 }
 
 struct RemarkAndCategoryView: View {
     let recipe: Recipe
-    @Binding var selectedItem: SelectedItem?
-    @Binding var selectedDetail: String?
+    @Environment(\.craftifyAccentColor) private var accent
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @State private var isUtilityExpanded = false
 
     var body: some View {
         if recipe.imageremark?.isEmpty == false || recipe.remarks?.isEmpty == false {
@@ -541,40 +575,47 @@ struct RemarkAndCategoryView: View {
                 )
 
                 if let imageRemark = recipe.imageremark, !imageRemark.isEmpty {
-                    Button {
-                        selectedDetail = imageRemark
-                        selectedItem = .imageremark
-                        HapticFeedback.impact()
+                    DisclosureGroup(isExpanded: $isUtilityExpanded) {
+                        Group {
+                            if dynamicTypeSize.isAccessibilitySize {
+                                VStack(alignment: .leading, spacing: 12) {
+                                    utilityImage(imageRemark)
+                                    utilityCopy(imageRemark)
+                                }
+                            } else {
+                                HStack(alignment: .top, spacing: 14) {
+                                    utilityImage(imageRemark)
+                                    utilityCopy(imageRemark)
+                                }
+                            }
+                        }
+                        .padding(.top, 12)
                     } label: {
                         HStack(spacing: 13) {
-                            CraftImage(key: imageRemark)
-                                .scaledToFit()
-                                .frame(width: 48, height: 48)
-                                .padding(5)
-                                .background(Color.userAccentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            Image(systemName: "hammer.fill")
+                                .font(.headline)
+                                .foregroundStyle(accent)
+                                .frame(width: 40, height: 40)
+                                .background(accent.opacity(0.10), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
                                 .accessibilityHidden(true)
                             VStack(alignment: .leading, spacing: 3) {
-                                Text(imageRemark)
+                                Text("Required Crafting Utility")
                                     .font(.headline)
                                     .foregroundStyle(.primary)
-                                Text("Required crafting utility")
+                                Text(isUtilityExpanded ? "Hide utility details" : "Show utility details")
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
                             }
-                            Spacer()
-                            Image(systemName: "info.circle.fill")
-                                .foregroundStyle(Color.userAccentColor)
-                                .accessibilityHidden(true)
                         }
-                        .padding(12)
-                        .background(Color.primary.opacity(0.045), in: RoundedRectangle(cornerRadius: 15, style: .continuous))
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Crafting utility: \(imageRemark)")
-                    .accessibilityHint("Shows crafting notes")
+                    .tint(accent)
+                    .onChange(of: isUtilityExpanded) { _, _ in HapticFeedback.selection() }
+                    .accessibilityHint("Shows the required utility and crafting notes")
                 }
 
-                if let remarks = recipe.remarks, !remarks.isEmpty {
+                if recipe.imageremark?.isEmpty != false,
+                   let remarks = recipe.remarks,
+                   !remarks.isEmpty {
                     Text(remarks)
                         .font(.body)
                         .foregroundStyle(.secondary)
@@ -583,6 +624,34 @@ struct RemarkAndCategoryView: View {
             }
             .padding(18)
             .craftifyCard(cornerRadius: 22)
+        }
+    }
+
+    private func utilityImage(_ imageRemark: String) -> some View {
+        CraftImage(key: imageRemark)
+            .scaledToFit()
+            .frame(width: 64, height: 64)
+            .padding(7)
+            .background(accent.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .accessibilityHidden(true)
+    }
+
+    private func utilityCopy(_ imageRemark: String) -> some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(imageRemark)
+                .font(.headline)
+            Text("Use this utility for the crafting layout shown above.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let remarks = recipe.remarks, !remarks.isEmpty {
+                Text(remarks)
+                    .font(.body)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.top, 4)
+            }
         }
     }
 }
@@ -654,6 +723,7 @@ struct GridCell: View {
     let isSelected: Bool
     let cellSize: CGFloat
     let onTap: () -> Void
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         Button {
@@ -663,11 +733,11 @@ struct GridCell: View {
         } label: {
             ZStack {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(ingredient.isEmpty ? Color.primary.opacity(0.035) : Color.userAccentColor.opacity(0.075))
+                    .fill(ingredient.isEmpty ? Color.primary.opacity(0.035) : accent.opacity(0.075))
                     .overlay {
                         RoundedRectangle(cornerRadius: 14, style: .continuous)
                             .stroke(
-                                isSelected ? Color.userAccentColor : Color.primary.opacity(ingredient.isEmpty ? 0.05 : 0.10),
+                                isSelected ? accent : Color.primary.opacity(ingredient.isEmpty ? 0.05 : 0.10),
                                 lineWidth: isSelected ? 2 : 1
                             )
                     }

--- a/Craftify/RecipeSearchView.swift
+++ b/Craftify/RecipeSearchView.swift
@@ -11,6 +11,7 @@ struct RecipeSearchView: View {
     @EnvironmentObject private var dataManager: DataManager
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
     @State private var searchText = ""
     @State private var isSearchActive = false
     @State private var filteredRecipes: [String: [Recipe]] = [:]
@@ -194,7 +195,7 @@ struct RecipeSearchView: View {
                 VStack(alignment: .leading, spacing: 10) {
                     Text(letter)
                         .font(.title2.bold())
-                        .foregroundStyle(Color.userAccentColor)
+                        .foregroundStyle(accent)
                         .accessibilityAddTraits(.isHeader)
 
                     LazyVGrid(columns: resultColumns, alignment: .leading, spacing: 12) {
@@ -222,7 +223,7 @@ struct RecipeSearchView: View {
 
     private var loadingState: some View {
         VStack(spacing: 14) {
-            ProgressView().controlSize(.large).tint(Color.userAccentColor)
+            ProgressView().controlSize(.large).tint(accent)
             Text("Loading Recipes…").font(.headline)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -254,6 +255,7 @@ struct RecipeSearchView: View {
 struct RecentSearchItem: View {
     let recipe: Recipe
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         HStack(spacing: 13) {
@@ -261,7 +263,7 @@ struct RecentSearchItem: View {
                 .scaledToFit()
                 .frame(width: 48, height: 48)
                 .padding(5)
-                .background(Color.userAccentColor.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .background(accent.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 3) {

--- a/Craftify/ReleaseNotesView.swift
+++ b/Craftify/ReleaseNotesView.swift
@@ -30,7 +30,7 @@ struct ReleaseNotesView: View {
                     ReleaseNoteCard(note: note, isCurrent: index == 0)
                 }
             }
-            .craftifyContentWidth(CraftifyLayout.readingMaxWidth)
+            .craftifyContentWidth()
             .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
             .padding(.top, 12)
             .padding(.bottom, 34)
@@ -44,6 +44,7 @@ struct ReleaseNotesView: View {
 private struct ReleaseNoteCard: View {
     let note: ReleaseNote
     let isCurrent: Bool
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
@@ -61,7 +62,7 @@ private struct ReleaseNoteCard: View {
                 ForEach(note.changes, id: \.self) { change in
                     HStack(alignment: .top, spacing: 11) {
                         Image(systemName: "checkmark.circle.fill")
-                            .foregroundStyle(Color.userAccentColor)
+                            .foregroundStyle(accent)
                             .accessibilityHidden(true)
                         Text(change)
                             .font(.body)
@@ -76,7 +77,7 @@ private struct ReleaseNoteCard: View {
         .craftifyCard(cornerRadius: 22)
         .overlay(alignment: .leading) {
             RoundedRectangle(cornerRadius: 3, style: .continuous)
-                .fill(isCurrent ? Color.userAccentColor : Color.userAccentColor.opacity(0.28))
+                .fill(isCurrent ? accent : accent.opacity(0.28))
                 .frame(width: 4)
                 .padding(.vertical, 18)
         }
@@ -89,9 +90,6 @@ struct ReleaseNote {
 }
 
 let releaseNotes: [ReleaseNote] = [
-    ReleaseNote(version: "Version 1.0 - Build 112", changes: [
-        "Experimental: Craftify Unified UI"
-    ]),
     ReleaseNote(version: "Version 1.0 - Build 113-121", changes: [
         "New feature: Chests. Organise your recipes the way you prefer",
         "New feature: Fully cloud-based recipe database",

--- a/Craftify/ReleaseNotesView.swift
+++ b/Craftify/ReleaseNotesView.swift
@@ -90,6 +90,9 @@ struct ReleaseNote {
 }
 
 let releaseNotes: [ReleaseNote] = [
+    ReleaseNote(version: "Version 1.0 - Build 112", changes: [
+        "Experimental: Craftify Unified UI"
+    ]),
     ReleaseNote(version: "Version 1.0 - Build 113-121", changes: [
         "New feature: Chests. Organise your recipes the way you prefer",
         "New feature: Fully cloud-based recipe database",

--- a/Craftify/ReportRecipeView.swift
+++ b/Craftify/ReportRecipeView.swift
@@ -113,13 +113,11 @@ struct ReportRecipeView: View {
                     }
                 }
                 .frame(maxWidth: .infinity)
-                .frame(maxWidth: CraftifyLayout.formMaxWidth)
+                .frame(maxWidth: CraftifyLayout.contentMaxWidth)
                 .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
                 .padding(.top, 12)
                 .padding(.bottom, 32)
             }
-            .id(accentColorPreference)
-
             if showSubmissionPopup {
                 SubmissionPopup(state: submissionState, onDismiss: dismissSubmissionPopup)
                     .transition(.opacity.combined(with: .scale(scale: 0.96)))
@@ -187,7 +185,7 @@ struct ReportRecipeView: View {
                         .foregroundStyle(viewMode == mode ? Color.white : Color.primary)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 11)
-                        .background(viewMode == mode ? Color.userAccentColor : Color.clear, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .background(viewMode == mode ? Color.userAccentColor(for: accentColorPreference) : Color.clear, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
                 }
                 .buttonStyle(.plain)
                 .accessibilityAddTraits(viewMode == mode ? .isSelected : [])
@@ -306,6 +304,7 @@ private struct SubmitReportSection: View {
     let onSubmit: () -> Void
 
     @EnvironmentObject private var dataManager: DataManager
+    @Environment(\.craftifyAccentColor) private var accent
     @FocusState private var focusedField: Field?
 
     private enum Field { case name, details }
@@ -356,7 +355,7 @@ private struct SubmitReportSection: View {
                 .foregroundStyle(.white)
                 .padding(.horizontal, 18)
                 .frame(minHeight: 54)
-                .background(Color.userAccentColor.gradient, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                .background(accent.gradient, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
                 .opacity(isFormIncomplete || !dataManager.isConnected || isSubmissionOnCooldown ? 0.45 : 1)
             }
             .buttonStyle(.plain)
@@ -375,9 +374,9 @@ private struct SubmitReportSection: View {
             Spacer()
             Text("\(completedSteps)/4")
                 .font(.caption.bold())
-                .foregroundStyle(Color.userAccentColor)
+                .foregroundStyle(accent)
                 .padding(.horizontal, 9).padding(.vertical, 5)
-                .background(Color.userAccentColor.opacity(0.12), in: Capsule())
+                .background(accent.opacity(0.12), in: Capsule())
         }
     }
 
@@ -406,7 +405,7 @@ private struct SubmitReportSection: View {
             VStack(alignment: .leading, spacing: 10) {
                 Image(systemName: type.icon)
                     .font(.title3.weight(.semibold))
-                    .foregroundStyle(reportType == type ? Color.white : Color.userAccentColor)
+                    .foregroundStyle(reportType == type ? Color.white : accent)
                 Text(type.title).font(.subheadline.bold())
                     .foregroundStyle(reportType == type ? Color.white : Color.primary)
                 Text(type == .missingRecipe ? "Request a new guide" : "Flag incorrect steps")
@@ -416,7 +415,7 @@ private struct SubmitReportSection: View {
             }
             .frame(maxWidth: .infinity, minHeight: 100, alignment: .leading)
             .padding(14)
-            .background(reportType == type ? Color.userAccentColor : Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .background(reportType == type ? accent : Color(uiColor: .secondarySystemGroupedBackground), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
             .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(reportType == type ? Color.clear : Color.primary.opacity(0.06)))
         }
         .buttonStyle(.plain)
@@ -427,7 +426,7 @@ private struct SubmitReportSection: View {
         VStack(alignment: .leading, spacing: 18) {
             Label(reportType.subtitle, systemImage: reportType.icon)
                 .font(.subheadline.weight(.medium))
-                .foregroundStyle(Color.userAccentColor)
+                .foregroundStyle(accent)
 
             LabeledContentField(title: "Recipe name", icon: "cube.fill") {
                 TextField("e.g. Copper Torch", text: activeName)
@@ -451,7 +450,7 @@ private struct SubmitReportSection: View {
                     ForEach(categories, id: \.self) { Text($0).tag($0) }
                 }
                 .pickerStyle(.menu)
-                .tint(activeCategory.wrappedValue.isEmpty ? .secondary : Color.userAccentColor)
+                .tint(activeCategory.wrappedValue.isEmpty ? .secondary : accent)
             }
 
             Divider()
@@ -529,6 +528,7 @@ private struct MyReportsSection: View {
     let errorMessage: String?
     let onRefresh: () -> Void
     let onDelete: (RecipeReport) -> Void
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -546,7 +546,7 @@ private struct MyReportsSection: View {
                     Image(systemName: "arrow.clockwise")
                         .font(.body.bold())
                         .frame(width: 38, height: 38)
-                        .background(Color.userAccentColor.opacity(0.12), in: Circle())
+                        .background(accent.opacity(0.12), in: Circle())
                 }
                 .disabled(isLoadingReports || !isConnected)
                 .accessibilityLabel("Refresh reports")
@@ -574,7 +574,7 @@ private struct MyReportsSection: View {
 
     private var loadingCard: some View {
         HStack(spacing: 12) {
-            ProgressView().tint(Color.userAccentColor)
+            ProgressView().tint(accent)
             VStack(alignment: .leading, spacing: 3) {
                 Text("Checking for updates").font(.headline)
                 Text("This should only take a moment.").font(.subheadline).foregroundStyle(.secondary)
@@ -591,14 +591,15 @@ private struct EmptyReportState: View {
     let icon: String
     let title: String
     let message: String
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         VStack(spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 30, weight: .medium))
-                .foregroundStyle(Color.userAccentColor)
+                .foregroundStyle(accent)
                 .frame(width: 64, height: 64)
-                .background(Color.userAccentColor.opacity(0.12), in: Circle())
+                .background(accent.opacity(0.12), in: Circle())
             Text(title).font(.title3.bold())
             Text(message).font(.subheadline).foregroundStyle(.secondary).multilineTextAlignment(.center)
         }
@@ -613,6 +614,7 @@ private struct ReportCard: View {
     let report: RecipeReport
     let onDelete: () -> Void
     @State private var isExpanded = false
+    @Environment(\.craftifyAccentColor) private var accent
 
     private var isPending: Bool { report.status.localizedCaseInsensitiveContains("pending") }
     private var isResolved: Bool {
@@ -620,7 +622,7 @@ private struct ReportCard: View {
             || report.status.localizedCaseInsensitiveContains("complete")
             || report.status.localizedCaseInsensitiveContains("fixed")
     }
-    private var statusColor: Color { isPending ? .orange : (isResolved ? .green : Color.userAccentColor) }
+    private var statusColor: Color { isPending ? .orange : (isResolved ? .green : accent) }
     private var statusIcon: String { isPending ? "clock.fill" : (isResolved ? "checkmark.circle.fill" : "arrow.triangle.2.circlepath") }
     private var isMissingRecipe: Bool { report.reportType == "Report Missing Recipe" }
 
@@ -633,9 +635,9 @@ private struct ReportCard: View {
                 HStack(spacing: 12) {
                     Image(systemName: isMissingRecipe ? "plus.magnifyingglass" : "exclamationmark.triangle.fill")
                         .font(.title3.weight(.semibold))
-                        .foregroundStyle(Color.userAccentColor)
+                        .foregroundStyle(accent)
                         .frame(width: 44, height: 44)
-                        .background(Color.userAccentColor.opacity(0.12), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        .background(accent.opacity(0.12), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
                     VStack(alignment: .leading, spacing: 4) {
                         Text(report.recipeName).font(.headline).foregroundStyle(.primary).lineLimit(2)
                         Text("\(isMissingRecipe ? "Missing recipe" : "Recipe error") • \(report.category)")
@@ -685,6 +687,7 @@ private struct ReportCard: View {
 private struct SubmissionPopup: View {
     let state: ReportRecipeView.SubmissionState
     let onDismiss: () -> Void
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         ZStack {
@@ -693,7 +696,7 @@ private struct SubmissionPopup: View {
             VStack(spacing: 18) {
                 switch state {
                 case .submitting:
-                    ProgressView().controlSize(.large).tint(Color.userAccentColor)
+                    ProgressView().controlSize(.large).tint(accent)
                     Text("Sending your report…").font(.headline)
                     Text("Hang tight while we securely save your feedback.")
                         .font(.subheadline).foregroundStyle(.secondary).multilineTextAlignment(.center)
@@ -713,7 +716,7 @@ private struct SubmissionPopup: View {
                     Button("Done", action: onDismiss)
                         .font(.headline).foregroundStyle(.white)
                         .frame(maxWidth: .infinity, minHeight: 48)
-                        .background(Color.userAccentColor, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                        .background(accent, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
                 }
             }
             .padding(24)
@@ -735,6 +738,7 @@ private struct SubmissionPopup: View {
 private struct DeleteConfirmationPopup: View {
     let message: String
     let onDismiss: () -> Void
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         ZStack {
@@ -748,7 +752,7 @@ private struct DeleteConfirmationPopup: View {
                 Button("Done", action: onDismiss)
                     .font(.headline).foregroundStyle(.white)
                     .frame(maxWidth: .infinity, minHeight: 48)
-                    .background(Color.userAccentColor, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .background(accent, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
             }
             .padding(24).frame(maxWidth: 320)
             .craftifyFloatingSurface(cornerRadius: 24)

--- a/Craftify/SupportView.swift
+++ b/Craftify/SupportView.swift
@@ -86,7 +86,7 @@ struct SupportView: View {
                 .padding(18)
                 .craftifyCard(cornerRadius: 22)
             }
-            .craftifyContentWidth(CraftifyLayout.readingMaxWidth)
+            .craftifyContentWidth()
             .padding(.horizontal, CraftifyLayout.pagePadding(for: horizontalSizeClass))
             .padding(.top, 12)
             .padding(.bottom, 34)

--- a/Craftify/SyncOverlayView.swift
+++ b/Craftify/SyncOverlayView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SyncOverlayView: View {
     let horizontalSizeClass: UserInterfaceSizeClass?
     let message: String
+    @Environment(\.craftifyAccentColor) private var accent
 
     var body: some View {
         CraftifyOverlayCard(
@@ -20,7 +21,7 @@ struct SyncOverlayView: View {
             badgeSymbol: "icloud.fill"
         ) {
             ProgressView()
-                .tint(Color.userAccentColor)
+                .tint(accent)
                 .controlSize(.small)
                 .accessibilityHidden(true)
         }
@@ -41,6 +42,7 @@ struct NewRecipesOverlayView: View {
     let onDismiss: () -> Void
 
     @State private var page: Page = .summary
+    @Environment(\.craftifyAccentColor) private var accent
 
     private var recipeCount: Int {
         recipes.count
@@ -108,7 +110,7 @@ struct NewRecipesOverlayView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.large)
-            .tint(Color.userAccentColor)
+            .tint(accent)
             .accessibilityHint("Shows the names and record IDs of the newly added recipes")
         }
     }
@@ -152,7 +154,7 @@ struct NewRecipesOverlayView: View {
             }
             .buttonStyle(.bordered)
             .controlSize(.large)
-            .tint(Color.userAccentColor)
+            .tint(accent)
             .accessibilityHint("Returns to the new recipe summary")
         }
     }
@@ -165,7 +167,7 @@ struct NewRecipesOverlayView: View {
         }
         .buttonStyle(.borderedProminent)
         .controlSize(.large)
-        .tint(Color.userAccentColor)
+        .tint(accent)
         .accessibilityHint("Dismisses this message and opens your recipe library")
     }
 }
@@ -217,6 +219,7 @@ private struct CraftifyOverlayCard<Footer: View>: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.craftifyAccentColor) private var accent
     @State private var isAnimating = false
 
     init(
@@ -297,7 +300,7 @@ private struct CraftifyOverlayCard<Footer: View>: View {
 
             Image(systemName: badgeSymbol)
                 .font(.system(size: 19, weight: .semibold))
-                .foregroundStyle(Color.userAccentColor)
+                .foregroundStyle(accent)
                 .padding(7)
                 .background(.regularMaterial, in: Circle())
                 .offset(x: 37, y: 37)


### PR DESCRIPTION
## What changed

- unify the Recipes navigation safe area, pinned category bar, and scrolling canvas
- extend the Craftify Picks atmosphere across each complete card
- separate ingredient/output details from the required crafting utility disclosure
- realign recipe detail content and make the related-recipe action fill its card
- compact the More sync control and command-card code/copy controls
- remove forced command-card height so cards wrap their content
- align App Icon, Release Notes, Support & Privacy, and About identity cards
- make all primary iPad screens use the same adaptive 1,180-point content canvas
- keep completed recipe and image progress visibly full during onboarding transitions

## Root causes fixed

Accent-dependent subviews were reading the selected colour through a static `UserDefaults` lookup, so SwiftUI did not consistently invalidate every already-rendered child. The shared design system now publishes one observed accent through the environment, and user-facing components consume that value directly without resetting navigation or form state.

Several screens also used older 760-, 820-, 900-, or 980-point caps while Recipes and Search used the shared adaptive canvas. Those caps are removed in favor of the common layout contract.

## User impact

Craftify now keeps one visual surface behind the Recipes header and content, uses consistent card/control widths and radii, responds immediately to accent changes, avoids excess command-card whitespace, presents crafting utilities without duplicated information, and makes better use of iPad portrait and landscape width.

## Validation

- Xcode 26 `Build Craftify for iOS/iPadOS 18` passed on GitHub Actions run 198
- parsed every Swift source file with the Swift tree-sitter grammar; no error or missing syntax nodes
- checked for conflict markers and trailing whitespace
- confirmed no UI tests depend on the adjusted labels or loading text
- compared the branch with current `main`: 15 intended Swift files, 0 unrelated files, branch 0 commits behind
- preserved the Build 112 release-note entry added directly to `main` after the original redesign